### PR TITLE
Remove `organization_name` from base URL - Part 2: view files

### DIFF
--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -54,7 +54,7 @@
                         text: "Export Adjustments"
                       ) if @adjustments.any? %>
 
-                  <%= new_button_to new_adjustment_path(organization_name: current_organization), {text: "New Adjustment"} %>
+                  <%= new_button_to new_adjustment_path, {text: "New Adjustment"} %>
                   </span>
               </div>
             <% end # form %>

--- a/app/views/admin/base_items/show.html.erb
+++ b/app/views/admin/base_items/show.html.erb
@@ -45,7 +45,7 @@
               <% @items.each do |item| %>
                 <tr id="item-row-<%= item.to_param %>">
                   <td><%= item.name %></td>
-                  <td><%= link_to item.organization.name, organization_path(item.organization) %></td>
+                  <td><%= item.organization.name %></td>
                 </tr>
               <% end %>
               </tbody>

--- a/app/views/admin/users/_roles.html.erb
+++ b/app/views/admin/users/_roles.html.erb
@@ -24,7 +24,7 @@
                 <% user.roles.each do |role| %>
                   <tr>
                     <td><%= role.title %></td>
-                    <td><%= link_to role.resource.name, role.resource %></td>
+                    <td><%= role.resource.name %></td>
                     <td class="text-right">
                       <%= delete_button_to admin_user_remove_role_path(user, role_id: role.id),
                                            confirm: "Are you sure you want to remove this role?" %>

--- a/app/views/audits/edit.html.erb
+++ b/app/views/audits/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Inventory Audits", (audits_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Inventory Audits", audits_path %></li>
           <li class="breadcrumb-item"><a href="#">New Audit</a></li>
         </ol>
       </div>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -47,7 +47,7 @@
                 <%= clear_filter_button %>
 
                 <div class="btn-group pull-right">
-                  <%= new_button_to new_audit_path(organization_name: current_organization), {text: "New Audit"} %>
+                  <%= new_button_to new_audit_path, {text: "New Audit"} %>
                 </div>
             <% end # form %>
             </div>

--- a/app/views/audits/new.html.erb
+++ b/app/views/audits/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Inventory Audits", (audits_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Inventory Audits", audits_path %></li>
           <li class="breadcrumb-item"><a href="#">New Audit</a></li>
         </ol>
       </div>

--- a/app/views/audits/show.html.erb
+++ b/app/views/audits/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Audits", (audits_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Audits", audits_path %></li>
           <li class="breadcrumb-item">Audit (<%= @audit.created_at.strftime("%m/%d/%Y") %>) - <%= @audit.status.titleize %></li>
         </ol>
       </div>

--- a/app/views/barcode_items/edit.html.erb
+++ b/app/views/barcode_items/edit.html.erb
@@ -13,7 +13,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Barcodes", (barcode_items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Barcodes", barcode_items_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing Barcode</a></li>
         </ol>
       </div>

--- a/app/views/barcode_items/index.html.erb
+++ b/app/views/barcode_items/index.html.erb
@@ -48,7 +48,7 @@
                 <span class="float-right">
                   <%= download_button_to(barcode_items_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Barcode Items", size: "md"}) if @barcode_items.any? %>
                   <%= download_button_to(font_barcode_items_path, {text: "Download Barcode Font"}) %>
-                  <%= new_button_to new_barcode_item_path(organization_name: current_organization), {text: "New Barcode"} %>
+                  <%= new_button_to new_barcode_item_path, {text: "New Barcode"} %>
                   </span>
               </div>
             <% end # form %>

--- a/app/views/barcode_items/new.html.erb
+++ b/app/views/barcode_items/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Barcodes", (barcode_items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Barcodes", barcode_items_path %></li>
           <li class="breadcrumb-item"><a href="#">New Barcode</a></li>
         </ol>
       </div>

--- a/app/views/barcode_items/show.html.erb
+++ b/app/views/barcode_items/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Barcodes", (barcode_items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Barcodes", barcode_items_path %></li>
           <li class="breadcrumb-item"><a href="#">Viewing Barcode</a></li>
         </ol>
       </div>

--- a/app/views/broadcast_announcements/edit.html.erb
+++ b/app/views/broadcast_announcements/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partners", partners_path %></li>
           <li class="breadcrumb-item"><%= link_to "Broadcast Announcements", broadcast_announcements_path %></li>
           <li class="breadcrumb-item"><%= link_to "Edit Announcements", edit_broadcast_announcement_path(@broadcast_announcement) %></li>
         </ol>

--- a/app/views/broadcast_announcements/index.html.erb
+++ b/app/views/broadcast_announcements/index.html.erb
@@ -31,7 +31,7 @@
           <!-- /.card-header -->
           <div class="card-body">
             <div class='flex justify-end mb-4'>
-              <%= new_button_to new_broadcast_announcement_path(organization_name: current_organization), {text: "New Announcement"} %>
+              <%= new_button_to new_broadcast_announcement_path, {text: "New Announcement"} %>
             </div>
             <table class="table table-responsive-md">
               <thead>

--- a/app/views/broadcast_announcements/index.html.erb
+++ b/app/views/broadcast_announcements/index.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partners", partners_path %></li>
           <li class="breadcrumb-item"><%= link_to "Broadcast Announcements", broadcast_announcements_path %></li>
         </ol>
       </div>

--- a/app/views/broadcast_announcements/new.html.erb
+++ b/app/views/broadcast_announcements/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partners", partners_path %></li>
           <li class="breadcrumb-item"><%= link_to "Broadcast Announcements", broadcast_announcements_url %></li>
           <li class="breadcrumb-item"><%= link_to "Send Announcement", new_broadcast_announcement_url %></li>
         </ol>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -51,7 +51,7 @@
             <div class="row">
               <div class="col-sm-3 col-6">
                 <div class="description-block border-right">
-                  <%= simple_form_for :filters, url: dashboard_path(current_organization), method: :get do |f| %>
+                  <%= simple_form_for :filters, url: dashboard_path, method: :get do |f| %>
                     <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %><br>
                     <%= filter_button %>
                   <% end %>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Distributions", (distributions_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Distributions", distributions_path %></li>
           <li class="breadcrumb-item"><a href="#">Edit Distribution</a></li>
         </ol>
       </div>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -76,7 +76,7 @@
                       )
                     end
                   %>
-                  <%= new_button_to new_distribution_path(organization_name: current_organization), {text: "New Distribution"} %>
+                  <%= new_button_to new_distribution_path, {text: "New Distribution"} %>
                 </span>
               </div>
             <% end # form %>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Distributions", (distributions_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Distributions", distributions_path %></li>
           <li class="breadcrumb-item"><a href="#">New Distribution</a></li>
         </ol>
       </div>

--- a/app/views/distributions/pickup_day.html.erb
+++ b/app/views/distributions/pickup_day.html.erb
@@ -13,8 +13,8 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Distributions", (distributions_path) %></li>
-          <li class="breadcrumb-item"><%= link_to "Schedule", (schedule_distributions_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Distributions", distributions_path %></li>
+          <li class="breadcrumb-item"><%= link_to "Schedule", schedule_distributions_path %></li>
         </ol>
       </div>
     </div>

--- a/app/views/distributions/schedule.html.erb
+++ b/app/views/distributions/schedule.html.erb
@@ -16,7 +16,7 @@
                 <i class="fa fa-dashboard"></i> Home
               <% end %>
             </li>
-            <li class="breadcrumb-item"><a href="#"><%= link_to "Distributions", (distributions_path) %></a></li>
+            <li class="breadcrumb-item"><a href="#"><%= link_to "Distributions", distributions_path %></a></li>
             <li class="breadcrumb-item active"><a href="#">Schedule</a></li>
           </ol>
         </div>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Distributions", (distributions_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Distributions", distributions_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @distribution.partner.name %>
             <% if @distribution.persisted? %>
               <%= "(#{@distribution.created_at.strftime("%m/%d/%Y")})" %></li>

--- a/app/views/donation_sites/edit.html.erb
+++ b/app/views/donation_sites/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Donation Sites", (donation_sites_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Donation Sites", donation_sites_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @donation_site.name %></a></li>
         </ol>
       </div>

--- a/app/views/donation_sites/index.html.erb
+++ b/app/views/donation_sites/index.html.erb
@@ -55,7 +55,7 @@
             <div class="pull-right">
               <%= modal_button_to("#csvImportModal", {icon: "upload", text: "Import Donation Sites", size: "md"}) if @donation_sites.empty? %>
               <%= download_button_to(donation_sites_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Donation Sites", size: "md"}) if @donation_sites.any? %>
-              <%= new_button_to new_donation_site_path(organization_name: current_organization), {text: "New Donation Site"} %>
+              <%= new_button_to new_donation_site_path, {text: "New Donation Site"} %>
             </div>
           </div>
         </div>

--- a/app/views/donation_sites/new.html.erb
+++ b/app/views/donation_sites/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Donation Sites", (donation_sites_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Donation Sites", donation_sites_path %></li>
           <li class="breadcrumb-item"><a href="#">New Donation Site</a></li>
         </ol>
       </div>

--- a/app/views/donation_sites/show.html.erb
+++ b/app/views/donation_sites/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Donation Sites", (donation_sites_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Donation Sites", donation_sites_path %></li>
           <li class="breadcrumb-item"><%= @donation_site.name %></li>
         </ol>
       </div>

--- a/app/views/donations/edit.html.erb
+++ b/app/views/donations/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Donations", (donations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Donations", donations_path %></li>
           <li class="breadcrumb-item">
             <a href="#">Editing <%= @donation.source %> on <%= @donation.created_at.to_fs(:distribution_date) %></a></li>
         </ol>

--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -81,7 +81,7 @@
                 <%= clear_filter_button %>
                 <span class="float-right">
                     <%= download_button_to(donations_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Donations", size: "md"}) if @donations.any? %>
-                  <%= new_button_to new_donation_path(organization_name: current_organization), {text: "New Donation"} %>
+                  <%= new_button_to new_donation_path, {text: "New Donation"} %>
                     </span>
               </div>
             <% end %>

--- a/app/views/donations/new.html.erb
+++ b/app/views/donations/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Donations", (donations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Donations", donations_path %></li>
           <li class="breadcrumb-item"><a href="#">New Donation</a></li>
         </ol>
       </div>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Donations", (donations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Donations", donations_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @donation.source %> on <%= @donation.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>

--- a/app/views/events/_event_row.html.erb
+++ b/app/views/events/_event_row.html.erb
@@ -11,7 +11,7 @@
     <td>
       <%= link_to event.eventable_id, event.eventable %>
       <%= link_to(
-          events_path(current_organization, eventable_type: event.eventable_type, eventable_id: event.eventable_id),
+          events_path(eventable_type: event.eventable_type, eventable_id: event.eventable_id),
           class: 'btn btn-md') do %>
         <i class="fa fa-filter"></i>
       <% end %>

--- a/app/views/items/_item_categories.html.erb
+++ b/app/views/items/_item_categories.html.erb
@@ -1,7 +1,7 @@
 <div class="tab-pane fade" id="custom-tabs-three-categories" role="tabpanel" aria-labelledby="custom-tabs-three-categories">
 
   <div class='flex justify-end mb-4'>
-    <%= new_button_to new_item_category_path(organization_name: current_organization), {text: "New Item Category"} %>
+    <%= new_button_to new_item_category_path, {text: "New Item Category"} %>
   </div>
 
   <table class="table">

--- a/app/views/items/_item_list.html.erb
+++ b/app/views/items/_item_list.html.erb
@@ -1,6 +1,6 @@
 <div class="tab-pane fade show active" id="custom-tabs-three-home" role="tabpanel" aria-labelledby="custom-tabs-three-home-tab">
   <div class='flex justify-end mb-4'>
-    <%= new_button_to new_item_path(organization_name: current_organization), {text: "New Item"} %>
+    <%= new_button_to new_item_path, {text: "New Item"} %>
   </div>
 
   <table id='items-table' class="table">

--- a/app/views/items/_items_inventory.html.erb
+++ b/app/views/items/_items_inventory.html.erb
@@ -1,6 +1,6 @@
 <div class="tab-pane fade" id="custom-tabs-three-inventory" role="tabpanel" aria-labelledby="custom-tabs-three-inventory-tab">
   <div class='flex justify-end mb-4'>
-    <%= new_button_to new_item_path(organization_name: current_organization), {text: "New Item"} %>
+    <%= new_button_to new_item_path, {text: "New Item"} %>
   </div>
 
   <table class="table table-items-location">

--- a/app/views/items/_items_quantity_and_location.html.erb
+++ b/app/views/items/_items_quantity_and_location.html.erb
@@ -1,6 +1,6 @@
 <div class="tab-pane fade" id="custom-tabs-three-profile" role="tabpanel" aria-labelledby="custom-tabs-three-profile-tab">
   <div class='flex justify-end mb-4'>
-    <%= new_button_to new_item_path(organization_name: current_organization), {text: "New Item"} %>
+    <%= new_button_to new_item_path, {text: "New Item"} %>
   </div>
 
   <table class="table table-items-location">

--- a/app/views/items/_kits.html.erb
+++ b/app/views/items/_kits.html.erb
@@ -1,6 +1,6 @@
 <div class="tab-pane fade" id="custom-tabs-three-kits" role="tabpanel" aria-labelledby="custom-tabs-three-kits-tab">
   <div class='flex justify-end mb-4'>
-    <%= new_button_to new_kit_path(organization_name: current_organization), {text: "New Kit"} %>
+    <%= new_button_to new_kit_path, {text: "New Kit"} %>
   </div>
 
   <%= render partial: 'kits/table' %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -13,7 +13,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Item Types", (items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Item Types", items_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @item.name %></a></li>
         </ol>
       </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Item Types", (items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Item Types", items_path %></li>
           <li class="breadcrumb-item"><a href="#">New Item Type</a></li>
         </ol>
       </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Item Types", (items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Item Types", items_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @item.name %></a></li>
         </ol>
       </div>

--- a/app/views/kits/_table.html.erb
+++ b/app/views/kits/_table.html.erb
@@ -44,7 +44,7 @@
           <% end %>
         </table>
         <div class='align-self-center'>
-          <%= edit_button_to allocations_kit_path(organization_name: current_organization.id, id: kit.id), { text: "Modify Allocation" } %>
+          <%= edit_button_to allocations_kit_path(kit), { text: "Modify Allocation" } %>
         </div>
       </td>
       <td>

--- a/app/views/kits/allocations.html.erb
+++ b/app/views/kits/allocations.html.erb
@@ -14,7 +14,7 @@
             <i class="fa fa-dashboard"></i> Home
           <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Items", (items_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Items", items_path %></li>
           <li class="breadcrumb-item"><a href="#">Kit Allocations</a></li>
         </ol>
       </div>

--- a/app/views/kits/index.html.erb
+++ b/app/views/kits/index.html.erb
@@ -44,7 +44,7 @@
             <%= filter_button %>
             <%= clear_filter_button %>
             <span class="float-right">
-              <%= new_button_to new_kit_path(organization_name: current_organization), { text: "New Kit" } %>
+              <%= new_button_to new_kit_path, { text: "New Kit" } %>
             </span>
           </div>
           <% end # form %>

--- a/app/views/layouts/_lte_admin_navbar.html.erb
+++ b/app/views/layouts/_lte_admin_navbar.html.erb
@@ -16,7 +16,7 @@
         <li class="user-body">
           <ul class="list-group">
             <li class="list-group-item">
-              <%= fa_icon "cog" %> <%= navigation_link_to "Account Settings", edit_user_registration_path(organization_name: nil) %>
+              <%= fa_icon "cog" %> <%= navigation_link_to "Account Settings", edit_user_registration_path %>
             </li>
           </ul>
         </li>
@@ -26,7 +26,7 @@
             <!-- <a href="#" class="btn btn-default btn-flat">Profile</a> -->
           </div>
           <div class="pull-right">
-            <%= delete_button_to destroy_user_session_path(organization_name: nil), {text: "Log out", icon: "sign-out", no_confirm: true, size: "md"} %>
+            <%= delete_button_to destroy_user_session_path, {text: "Log out", icon: "sign-out", no_confirm: true, size: "md"} %>
           </div>
         </li>
       </ul>

--- a/app/views/layouts/_lte_admin_sidebar.html.erb
+++ b/app/views/layouts/_lte_admin_sidebar.html.erb
@@ -141,7 +141,7 @@
 
   <% if (current_user.organization.present?) %>
     <li class="nav-item">
-      <%= link_to(dashboard_path(organization_name: current_user.organization), class: "nav-link") do %>
+      <%= link_to(dashboard_path, class: "nav-link") do %>
         <i class="nav-icon fas fa-home"></i>
         <p>My Organization</p>
       <% end %>

--- a/app/views/layouts/_lte_navbar.html.erb
+++ b/app/views/layouts/_lte_navbar.html.erb
@@ -35,7 +35,7 @@
       remaining this week
     </a>
     <div class="dropdown-divider"></div>
-    <%= link_to_if current_organization.id.present?, "View Calendar", schedule_distributions_path(organization_name: current_organization.to_param), class: "dropdown-item dropdown-footer" %>
+    <%= link_to_if current_organization.id.present?, "View Calendar", schedule_distributions_path, class: "dropdown-item dropdown-footer" %>
   </div>
 </li>
 
@@ -63,7 +63,7 @@
     <%= current_user.display_name %>
   </a>
   <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
-    <%= link_to edit_user_registration_path(organization_name: nil), class:"dropdown-item" do %>
+    <%= link_to edit_user_registration_path, class:"dropdown-item" do %>
     <i class="fa fa-cog text-aqua"></i> Account Settings
     <% end %>
     <% current_user.switchable_roles.each do |role| %>
@@ -74,20 +74,16 @@
     <% end %>
     <% if current_organization.id.present? &&
         (current_user.has_role?(Role::SUPER_ADMIN) || current_user.has_role?(Role::ORG_ADMIN, current_organization)) %>
-    <% with_options organization_name: current_user.organization.to_param do |with_org| %>
-
-    <div class="dropdown-divider"></div>
-    <%= link_to with_org.users_path, class:"dropdown-item" do %>
-    <i class="fas fa-users mr-2"></i> My Co-Workers
+        <div class="dropdown-divider"></div>
+        <%= link_to users_path, class:"dropdown-item" do %>
+          <i class="fas fa-users mr-2"></i> My Co-Workers
+        <% end %>
+        <%= link_to organization_path, class:"dropdown-item" do %>
+          <i class="fas fa-sitemap mr-2"></i> My Organization
+        <% end %>
     <% end %>
     <div class="dropdown-divider"></div>
-    <%= link_to with_org.organization_path, class:"dropdown-item" do %>
-    <i class="fas fa-sitemap mr-2"></i> My Organization
-    <% end %>
-    <% end %>
-    <% end %>
-    <div class="dropdown-divider"></div>
-    <%= link_to destroy_user_session_path(organization_name: nil), class:"dropdown-item dropdown-footer", method: :delete do %>
+    <%= link_to destroy_user_session_path, class:"dropdown-item dropdown-footer", method: :delete do %>
     <i class="fa fa-sign-out mr-2"></i> Log Out
     <% end %>
   </div>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
   <li class="nav-item">
-    <%= link_to(dashboard_path(organization_name: current_user.organization), class: "nav-link #{active_class(['dashboard'])}") do %>
+    <%= link_to(dashboard_path, class: "nav-link #{active_class(['dashboard'])}") do %>
       <i class="nav-icon fas fa-tachometer-alt"></i>
       <p>Dashboard</p>
     <% end %>
@@ -13,7 +13,7 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(product_drives_path) %>">
-        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path(organization_name: current_user.organization))}") do %>
+        <%= link_to(product_drives_path, class: "nav-link #{"active" if current_page?(product_drives_path)}") do %>
           <i class="nav-icon far fa-circle"></i>
           <p>All Product Drives</p>
         <% end %>
@@ -34,12 +34,12 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(donations_path) %>">
-        <%= link_to(donations_path(organization_name: current_user.organization), class: "nav-link #{"active" if current_page?(donations_path(organization_name: current_user.organization))}") do %>
+        <%= link_to(donations_path, class: "nav-link #{"active" if current_page?(donations_path)}") do %>
           <i class="nav-icon fa fa-circle-o"></i> All Donations
         <% end %>
       </li>
-      <li class="nav-item <%= 'active' if current_page?(new_donation_path(organization_name: current_user.organization)) %>">
-        <%= link_to(new_donation_path(organization_name: current_user.organization), class: "nav-link #{"active" if current_page?(new_donation_path)}") do %>
+      <li class="nav-item <%= 'active' if current_page?(new_donation_path) %>">
+        <%= link_to(new_donation_path, class: "nav-link #{"active" if current_page?(new_donation_path)}") do %>
           <i class="nav-icon fa fa-circle-o"></i> New Donation
         <% end %>
       </li>
@@ -53,12 +53,12 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= 'active' if current_page?(donations_path) %>">
-        <%= link_to(purchases_path(organization_name: current_user.organization), class: "nav-link #{"active" if current_page?(purchases_path(organization_name: current_user.organization))}") do %>
+        <%= link_to(purchases_path, class: "nav-link #{"active" if current_page?(purchases_path)}") do %>
           <i class="nav-icon fa fa-circle-o"></i> All Purchases
         <% end %>
       </li>
-      <li class="nav-item <%= 'active' if current_page?(new_purchase_path(organization_name: current_user.organization)) %>">
-        <%= link_to(new_purchase_path(organization_name: current_user.organization), class: "nav-link #{"active" if current_page?(new_purchase_path)}") do %>
+      <li class="nav-item <%= 'active' if current_page?(new_purchase_path) %>">
+        <%= link_to(new_purchase_path, class: "nav-link #{"active" if current_page?(new_purchase_path)}") do %>
           <i class="nav-icon fa fa-circle-o"></i> New Purchase
         <% end %>
       </li>
@@ -109,33 +109,33 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= active_class(['items']) %>">
-        <%= link_to(items_path(organization_name: current_user.organization), class: "nav-link #{active_class(['items'])}") do %>
+        <%= link_to(items_path, class: "nav-link #{active_class(['items'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Items &amp; Inventory
         <% end %>
       </li>
 
       <li class="nav-item <%= active_class(['kits']) %>">
-        <%= link_to(kits_path(organization_name: current_user.organization), class: "nav-link #{active_class(['kits'])}") do %>
+        <%= link_to(kits_path, class: "nav-link #{active_class(['kits'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Kits
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['barcode_items']) %>">
-        <%= link_to(barcode_items_path(organization_name: current_user.organization), class: "nav-link #{active_class(['barcode_items'])}") do %>
+        <%= link_to(barcode_items_path, class: "nav-link #{active_class(['barcode_items'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Barcode Items
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['storage_locations']) %>">
-        <%= link_to(storage_locations_path(organization_name: current_user.organization), class: "nav-link #{active_class(['storage_locations'])}") do %>
+        <%= link_to(storage_locations_path, class: "nav-link #{active_class(['storage_locations'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Storage Locations
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['adjustments']) %>">
-        <%= link_to(adjustments_path(organization_name: current_user.organization), class: "nav-link #{active_class(['adjustments'])}") do %>
+        <%= link_to(adjustments_path, class: "nav-link #{active_class(['adjustments'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Inventory Adjustments
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['transfers']) %>">
-        <%= link_to(transfers_path(organization_name: current_user.organization), class: "nav-link #{active_class(['transfers'])}") do %>
+        <%= link_to(transfers_path, class: "nav-link #{active_class(['transfers'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Transfers
         <% end %>
       </li>
@@ -149,22 +149,22 @@
     </a>
     <ul class="nav nav-treeview">
       <li class="nav-item <%= active_class(['donation_sites']) %>">
-        <%= link_to(donation_sites_path(organization_name: current_user.organization), class: "nav-link #{active_class(['donation_sites'])}") do %>
+        <%= link_to(donation_sites_path, class: "nav-link #{active_class(['donation_sites'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Donation Sites
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['product_drive_participants']) %>">
-        <%= link_to(product_drive_participants_path(organization_name: current_user.organization), class: "nav-link #{active_class(['product_drive_participants'])}") do %>
+        <%= link_to(product_drive_participants_path, class: "nav-link #{active_class(['product_drive_participants'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Product Drive Participants
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['manufacturers']) %>">
-        <%= link_to(manufacturers_path(organization_name: current_user.organization), class: "nav-link #{active_class(['manufacturers'])}") do %>
+        <%= link_to(manufacturers_path, class: "nav-link #{active_class(['manufacturers'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Manufacturers
         <% end %>
       </li>
       <li class="nav-item <%= active_class(['vendors']) %>">
-        <%= link_to(vendors_path(organization_name: current_user.organization), class: "nav-link #{active_class(['vendors'])}") do %>
+        <%= link_to(vendors_path, class: "nav-link #{active_class(['vendors'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Vendors
         <% end %>
       </li>
@@ -180,18 +180,18 @@
       </a>
       <ul class="nav nav-treeview">
         <li class="nav-item <%= active_class(['audits']) %>">
-          <%= link_to(audits_path(organization_name: current_user.organization), class: "nav-link #{active_class(['audits'])}") do %>
+          <%= link_to(audits_path, class: "nav-link #{active_class(['audits'])}") do %>
             <i class="nav-icon fa fa-circle-o"></i> Inventory Audit
           <% end %>
         </li>
         <li class="nav-item <%= active_class(['reports']) %>">
-          <%= link_to(reports_annual_reports_path(organization_name: current_user.organization), class: "nav-link #{active_class(['reports'])}") do %>
+          <%= link_to(reports_annual_reports_path, class: "nav-link #{active_class(['reports'])}") do %>
             <i class="nav-icon fa fa-circle-o"></i> Annual Survey
           <% end %>
         </li>
         <% if Event.read_events?(current_user.organization) %>
           <li class="nav-item <%= active_class(['events']) %>">
-            <%= link_to(events_path(organization_name: current_user.organization), class: "nav-link #{active_class(['events'])}") do %>
+            <%= link_to(events_path, class: "nav-link #{active_class(['events'])}") do %>
               <i class="nav-icon fa fa-circle-o"></i> History
             <% end %>
           </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
         <div class="navbar-custom-menu">
           <ul class="nav navbar-nav">
             <li class="user user-menu">
-              <%= delete_button_to destroy_user_session_path(organization_name: nil), {text: "Log out", icon: "sign-out", no_confirm: true, size: "md"} %>
+              <%= delete_button_to destroy_user_session_path, {text: "Log out", icon: "sign-out", no_confirm: true, size: "md"} %>
             </li>
           </ul>
         </div>

--- a/app/views/layouts/application_old.html.erb
+++ b/app/views/layouts/application_old.html.erb
@@ -52,7 +52,7 @@
         <div class="navbar-custom-menu">
           <ul class="nav navbar-nav">
             <li class="user user-menu">
-              <%= delete_button_to destroy_user_session_path(organization_name: nil), { text: "Log out", icon: "sign-out", no_confirm: true, size: "md" } %>
+              <%= delete_button_to destroy_user_session_path, { text: "Log out", icon: "sign-out", no_confirm: true, size: "md" } %>
             </li>
           </ul>
         </div>

--- a/app/views/layouts/partners/navigation/_navbar.html.erb
+++ b/app/views/layouts/partners/navigation/_navbar.html.erb
@@ -21,7 +21,7 @@
     <div class="dropdown-divider"></div>
     <% current_user.switchable_roles.each do |role| %>
       <% next if role == current_role %>
-      <%= link_to switch_to_role_users_path(organization_name: current_partner.organization, role_id: role.id), class:"dropdown-item" do %>
+      <%= link_to switch_to_role_users_path(role_id: role.id), class:"dropdown-item" do %>
         <i class="fa fa-repeat text-aqua"></i><%= "Switch to: #{role.resource.name}" %>
       <% end %>
     <% end %>

--- a/app/views/manufacturers/edit.html.erb
+++ b/app/views/manufacturers/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Manufacturers", (manufacturers_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Manufacturers", manufacturers_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @manufacturer.name %></a></li>
         </ol>
       </div>

--- a/app/views/manufacturers/index.html.erb
+++ b/app/views/manufacturers/index.html.erb
@@ -31,7 +31,7 @@
         <div class="card card-primary">
           <div class="card-footer">
             <div class="pull-right">
-              <%= new_button_to new_manufacturer_path(organization_name: current_organization), text: "New Manufacturer" %>
+              <%= new_button_to new_manufacturer_path, text: "New Manufacturer" %>
             </div>
           </div>
         </div>

--- a/app/views/manufacturers/new.html.erb
+++ b/app/views/manufacturers/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Manufacturers", (manufacturers_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Manufacturers", manufacturers_path %></li>
           <li class="breadcrumb-item"><a href="#">New Manufacturer</a></li>
         </ol>
       </div>

--- a/app/views/manufacturers/show.html.erb
+++ b/app/views/manufacturers/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Manufacturers", (manufacturers_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Manufacturers", manufacturers_path %></li>
           <li class="breadcrumb-item"><%= @manufacturer.name %></li>
         </ol>
       </div>

--- a/app/views/organization_mailer/partner_approval_request.html.erb
+++ b/app/views/organization_mailer/partner_approval_request.html.erb
@@ -2,4 +2,4 @@
 
 <br>
 
-<%= link_to 'Review This Partner', partner_url(organization_name: @organization.short_name, id: @partner.id, anchor: "partner-information") %>
+<%= link_to 'Review This Partner', partner_url(id: @partner.id, anchor: "partner-information") %>

--- a/app/views/organization_mailer/partner_approval_request.text.erb
+++ b/app/views/organization_mailer/partner_approval_request.text.erb
@@ -1,3 +1,3 @@
 You've received a request to approve the account for <%= @partner.name %>.
 
-Review This Partner: <%= partner_url(organization_name: @organization.short_name, id: @partner.id, anchor: "partner-information") %>
+Review This Partner: <%= partner_url(id: @partner.id, anchor: "partner-information") %>

--- a/app/views/partner_groups/edit.html.erb
+++ b/app/views/partner_groups/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partner Groups", (partner_groups_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partner Groups", partner_groups_path %></li>
           <li class="breadcrumb-item"><a href="#">Updating <%= @partner_group.name %></a></li>
         </ol>
       </div>

--- a/app/views/partner_groups/new.html.erb
+++ b/app/views/partner_groups/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partners", partners_path %></li>
           <li class="breadcrumb-item"><a href="#">New Partner</a></li>
         </ol>
       </div>

--- a/app/views/partners/_partner_groups_table.html.erb
+++ b/app/views/partners/_partner_groups_table.html.erb
@@ -5,7 +5,7 @@
       <div class="col-12">
         <!-- Default box -->
         <div class='flex justify-end mb-2'>
-          <%= new_button_to new_partner_group_path(organization_name: current_organization), {text: "New Partner Group"} %>
+          <%= new_button_to new_partner_group_path, {text: "New Partner Group"} %>
         </div>
 
         <div class="card">

--- a/app/views/partners/_partners_table.html.erb
+++ b/app/views/partners/_partners_table.html.erb
@@ -12,7 +12,7 @@
           <div class="pull-right">
             <%= modal_button_to("#csvImportModal", {text: "Import Partners", icon: "upload", size: "md"}) %>
             <%= download_button_to(partners_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Partner Agencies", size: "md"}) if @partners.any? %>
-            <%= new_button_to new_partner_path(organization_name: current_organization), {text: "New Partner Agency"} %>
+            <%= new_button_to new_partner_path, {text: "New Partner Agency"} %>
           </div>
         </div>
       </div>

--- a/app/views/partners/_statuses.html.erb
+++ b/app/views/partners/_statuses.html.erb
@@ -13,7 +13,7 @@
     partner_count = partners.select(&selector).size %>
   <li>
     <%= fa_icon icon_mapping[status] || '', class: "bg-partner-#{status}  " %>
-    <%= link_to_unless partner_count.zero?, "#{partner_count} #{status.humanize}", partners_path(filters: { by_status: status }), class: ("filtering" if status == current_filtered_status) %>
+    <%= link_to_unless partner_count.zero?, "#{partner_count} #{status.humanize}", partners_path(organization_name:nil, filters: { by_status: status }), class: ("filtering" if status == current_filtered_status) %>
   </li>
   <% end %>
   <li>

--- a/app/views/partners/edit.html.erb
+++ b/app/views/partners/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partners", partners_path %></li>
           <li class="breadcrumb-item"><a href="#">Updating  <%= @partner.name %></a></li>
         </ol>
       </div>

--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Partners", partners_path %></li>
           <li class="breadcrumb-item"><a href="#">New Partner</a></li>
         </ol>
       </div>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Partners", (partners_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Partners", partners_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @partner.name %></a></li>
         </ol>
       </div>
@@ -337,6 +337,7 @@
                 <span class="input-group-text" id="spn_env_fa_icon"><%= fa_icon "envelope" %></span>
                 <input type="email" name="email" class="form-control" placeholder="Email" aria-describedby="spn_env_fa_icon" autocomplete="off">
                 <%= hidden_field_tag :partner_id, @partner.id %><br>
+                <%= hidden_field_tag :organization_name, current_organization %>
               </div>
               <br>
               <%= submit_button({ text: "Reset Password", icon: "envelope" }) %>

--- a/app/views/product_drive_participants/edit.html.erb
+++ b/app/views/product_drive_participants/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Product Drive Participants", (product_drive_participants_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Product Drive Participants", product_drive_participants_path %></li>
           <li class="breadcrumb-item"><a href="#">Update record for <%= @product_drive_participant.contact_name %></a></li>
         </ol>
       </div>

--- a/app/views/product_drive_participants/index.html.erb
+++ b/app/views/product_drive_participants/index.html.erb
@@ -34,7 +34,7 @@
               <%= modal_button_to("#csvImportModal", {icon: "upload", text: "Import Product Drive Participants", size: "md"}) if @product_drive_participants.empty? %>
               <%= download_button_to(product_drive_participants_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Product Drive Participants", size: "md"}) if @product_drive_participants.any? %>
 
-              <%= new_button_to new_product_drive_participant_path(organization_name: current_organization), text: "New Product Drive Participant" %>
+              <%= new_button_to new_product_drive_participant_path, text: "New Product Drive Participant" %>
             </div>
           </div>
         </div>

--- a/app/views/product_drive_participants/new.html.erb
+++ b/app/views/product_drive_participants/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Product Drive Participants", (product_drive_participants_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Product Drive Participants", product_drive_participants_path %></li>
           <li class="breadcrumb-item"><a href="#">New Product Drive Participant</a></li>
         </ol>
       </div>

--- a/app/views/product_drive_participants/show.html.erb
+++ b/app/views/product_drive_participants/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Product Drive Participants", (product_drive_participants_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Product Drive Participants", product_drive_participants_path %></li>
           <li class="breadcrumb-item"><%= @product_drive_participant.contact_name %></li>
         </ol>
       </div>

--- a/app/views/product_drives/edit.html.erb
+++ b/app/views/product_drives/edit.html.erb
@@ -13,7 +13,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Product Drives", (product_drives_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Product Drives", product_drives_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @product_drive.name %> on <%= @product_drive.created_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>

--- a/app/views/product_drives/index.html.erb
+++ b/app/views/product_drives/index.html.erb
@@ -35,7 +35,7 @@
           <!-- /.card-header -->
           <!-- form start -->
           <div class="card-body">
-            <%= form_tag(product_drives_path, method: :get, organization_name: current_organization) do |f| %>
+            <%= form_tag(product_drives_path, method: :get) do |f| %>
               <div class="row">
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= filter_select(scope: :by_name, collection: @product_drives_alphabetical, key: :name, value: :name, selected: @selected_name_filter) %>
@@ -61,7 +61,7 @@
                       )
                     end
                   %>
-                  <%= new_button_to new_product_drive_path(organization_name: current_organization), {text: "New Product Drive"} %>
+                  <%= new_button_to new_product_drive_path, {text: "New Product Drive"} %>
                   </span>
               </div>
             <% end # form %>

--- a/app/views/product_drives/new.html.erb
+++ b/app/views/product_drives/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Product Drives", (product_drives_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Product Drives", product_drives_path %></li>
           <li class="breadcrumb-item"><a href="#">New Product Drive</a></li>
         </ol>
       </div>

--- a/app/views/product_drives/show.html.erb
+++ b/app/views/product_drives/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Product Drives", (product_drives_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Product Drives", product_drives_path %></li>
         </ol>
       </div>
     </div>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Purchases", (purchases_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Purchases", purchases_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @purchase.purchased_from_view %>
             on <%= @purchase.created_at.to_fs(:distribution_date) %></a></li>
         </ol>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -56,7 +56,7 @@
                 <%= cancel_button_to purchases_path, {text: "Clear Filters"} %>
                 <span class="float-right">
                   <%= download_button_to(purchases_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Purchases", size: "md"}) if @purchases.any? %>
-                  <%= new_button_to new_purchase_path(organization_name: current_organization), {text: "New Purchase"} %>
+                  <%= new_button_to new_purchase_path, {text: "New Purchase"} %>
                     </span>
               </div>
             <% end %>

--- a/app/views/purchases/new.html.erb
+++ b/app/views/purchases/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Purchases", (purchases_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Purchases", purchases_path %></li>
           <li class="breadcrumb-item"><a href="#">New Purchase</a></li>
         </ol>
       </div>

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Purchases", (purchases_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Purchases", purchases_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @purchase.purchased_from_view %> on <%= @purchase.issued_at.to_fs(:distribution_date) %></a></li>
         </ol>
       </div>

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -17,6 +17,6 @@
   </td>
   <td class="text-right">
     <%= view_button_to request_path(request_row) %>
-    <%= button_to 'Cancel', new_request_cancelation_path(organization: @organization, request_id: request_row.id), method: :get, class: 'btn btn-danger btn-xs' %>
+    <%= button_to 'Cancel', new_request_cancelation_path(request_id: request_row.id), method: :get, class: 'btn btn-danger btn-xs' %>
   </td>
 </tr>

--- a/app/views/requests/cancelation/new.html.erb
+++ b/app/views/requests/cancelation/new.html.erb
@@ -13,7 +13,7 @@
             <i class="fa fa-dashboard"></i> Home
           <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Requests", (requests_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Requests", requests_path %></li>
           <li class="breadcrumb-item"><a href="#"> Request Cancelation </a></li>
         </ol>
       </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -92,7 +92,7 @@
           <div class="card-footer flex flex-row space-x-2">
             <%= submit_button_to start_request_path(@request), {text: "Fulfill request", size: "md"} unless @request.distribution %>
             <%= view_button_to(distribution_path(@request.distribution), {text: "View Associated Distribution", size: "md"}) if @request.distribution %>
-            <%= button_to 'Cancel', new_request_cancelation_path(organization: @organization, request_id: @request.id),
+            <%= button_to 'Cancel', new_request_cancelation_path(request_id: @request.id),
                           method: :get, form_class: 'd-inline', class: 'btn btn-danger btn-md' %>
         </div>
       </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Requests", (requests_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Requests", requests_path %></li>
           <li class="breadcrumb-item"><a href="#"> Request from <%= @request.partner.name %>
             at <%= @request.created_at.to_fs(:distribution_date) %></a></li>
         </ol>

--- a/app/views/storage_locations/_source.html.erb
+++ b/app/views/storage_locations/_source.html.erb
@@ -14,7 +14,6 @@
   input_html: {
     data: {
       storage_location_inventory_path: inventory_storage_location_path(
-        organization_name: current_organization,
         include_omitted_items: include_omitted_items,
         id: ":id",
         format: :json

--- a/app/views/storage_locations/edit.html.erb
+++ b/app/views/storage_locations/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Storage Locations", (storage_locations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Storage Locations", storage_locations_path %></li>
           <li class="breadcrumb-item"><a href="#">Editing <%= @storage_location.name %></a></li>
         </ol>
       </div>

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -49,9 +49,9 @@
                 <%= filter_button %>
                 <%= clear_filter_button %>
                 <span class="float-right">
-                <%= modal_button_to("#csvImportModal", {icon: "upload", text: "Import Storage Locations"}) if @storage_locations.empty? %>
+                  <%= modal_button_to("#csvImportModal", {icon: "upload", text: "Import Storage Locations"}) if @storage_locations.empty? %>
                   <%= download_button_to(storage_locations_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Storage Locations", size: "md"}) if @storage_locations.any? %>
-                  <%= new_button_to new_storage_location_path(organization_name: current_organization), {text: "New Storage Location"} %>
+                  <%= new_button_to new_storage_location_path, {text: "New Storage Location"} %>
                   </span>
               </div>
             <% end # form %>

--- a/app/views/storage_locations/new.html.erb
+++ b/app/views/storage_locations/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Storage Locations", (storage_locations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Storage Locations", storage_locations_path %></li>
           <li class="breadcrumb-item"><a href="#">New Storage Location</a></li>
         </ol>
       </div>

--- a/app/views/storage_locations/show.html.erb
+++ b/app/views/storage_locations/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Storage Locations", (storage_locations_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Storage Locations", storage_locations_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @storage_location.name %></a></li>
         </ol>
       </div>

--- a/app/views/transfers/index.html.erb
+++ b/app/views/transfers/index.html.erb
@@ -48,7 +48,7 @@
                 <%= clear_filter_button %>
                 <span class="float-right">
                 <%= download_button_to(transfers_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Transfers", size: "md"}) if @transfers.any? %>
-                  <%= new_button_to new_transfer_path(organization_name: current_organization), {text: "New Transfer"} %>
+                  <%= new_button_to new_transfer_path, {text: "New Transfer"} %>
                   </span>
               </div>
             <% end # form %>

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Inventory Transfers", (transfers_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Inventory Transfers", transfers_path %></li>
           <li class="breadcrumb-item"><a href="#">New Transfer</a></li>
         </ol>
       </div>

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "All Transfers", (transfers_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "All Transfers", transfers_path %></li>
           <li class="breadcrumb-item"><a href="#"><%= @transfer.from.name %> to <%= @transfer.to.name %></a></li>
         </ol>
       </div>

--- a/app/views/users/_add_user_modal.erb
+++ b/app/views/users/_add_user_modal.erb
@@ -7,7 +7,7 @@
       </div><!-- modal-header -->
       <div class="modal-body">
         <div class="box-body">
-          <%= form_tag invite_user_organization_path(organization_name: current_organization.name) do %>
+          <%= form_tag invite_user_organization_path do %>
             <div class="input-group">
               <span class="input-group-text" id="spn_usr_fa_icon"><%= fa_icon "user" %></span>
               <input type="text" name="name" class="form-control" placeholder="Name" aria-describedby="spn_usr_fa_icon">

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -22,25 +22,25 @@
             <li>
               <%=
                   edit_button_to(
-                    promote_to_org_admin_organization_path(current_organization, user_id: user.id),
+                    promote_to_org_admin_organization_path(user_id: user.id),
                     {text: 'Make admin'},
                     {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}}
                   )
               %>
             </li>
             <li>
-              <%= deactivate_button_to deactivate_user_organization_path(current_organization, user_id: user.id),
+              <%= deactivate_button_to deactivate_user_organization_path(user_id: user.id),
                   {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} %>
             </li>
           <% else %>
-            <%= reactivate_button_to reactivate_user_organization_path(current_organization, user_id: user.id),
+            <%= reactivate_button_to reactivate_user_organization_path(user_id: user.id),
                 {id: dom_id(user), method: :post, class: 'reactivate', rel: "nofollow", data: {confirm: 'This will reactivate the user. Are you sure that you want to submit this?', size: 'xs'}} %>
           <% end %>
         </ul>
       </div>
     <% end %>
     <% if current_user.has_role?(Role::ORG_ADMIN, current_organization) && user.has_role?(Role::ORG_ADMIN, current_organization) %>
-      <%= edit_button_to demote_to_user_organization_path(current_organization, user_id: user.id),
+      <%= edit_button_to demote_to_user_organization_path(user_id: user.id),
                  {text: 'Make User'},
                  {method: :post, rel: "nofollow", data: {confirm: 'This will demote the admin to user status. Are you sure that you want to submit this?', size: 'xs'}} unless user.id == current_user.id %>
     <% end %>

--- a/app/views/users/shared/_account_management_menu.html.erb
+++ b/app/views/users/shared/_account_management_menu.html.erb
@@ -1,11 +1,9 @@
 <% content_for :sidebar do %>
   <ul class="vertical menu">
-    <li><%= navigation_link_to "Account Settings", edit_user_registration_path(organization_name: nil) %></li>
+    <li><%= navigation_link_to "Account Settings", edit_user_registration_path %></li>
 
-    <% with_options organization_name: current_user.organization.to_param do |with_org| %>
-      <li><%= navigation_link_to "All users", with_org.users_path %></li>
-      <li><%= navigation_link_to "Add a user", with_org.new_user_path %></li>
-      <li><%= navigation_link_to "Update organization", with_org.edit_organization_path %></li>
-    <% end %>
+    <li><%= navigation_link_to "All users", users_path %></li>
+    <li><%= navigation_link_to "Add a user", new_user_path %></li>
+    <li><%= navigation_link_to "Update organization", edit_organization_path %></li>
   </ul>
 <% end %>

--- a/app/views/vendors/edit.html.erb
+++ b/app/views/vendors/edit.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Vendors", (vendors_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Vendors", vendors_path %></li>
           <li class="breadcrumb-item"><a href="#">Update record for <%= @vendor.contact_name %></a></li>
         </ol>
       </div>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -33,7 +33,7 @@
             <div class="pull-right">
               <%= modal_button_to("#csvImportModal", { icon: "upload", text: "Import Vendors", size: "md"}) if @vendors.empty? %>
               <%= download_button_to(vendors_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Vendors", size: "md"}) if @vendors.any? %>
-              <%= new_button_to new_vendor_path(organization_name: current_organization), text: "New Vendor" %>            </div>
+              <%= new_button_to new_vendor_path, text: "New Vendor" %>            </div>
           </div>
         </div>
         <!-- /.card -->

--- a/app/views/vendors/new.html.erb
+++ b/app/views/vendors/new.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Vendors", (vendors_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Vendors", vendors_path %></li>
           <li class="breadcrumb-item"><a href="#">New Vendor</a></li>
         </ol>
       </div>

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -14,7 +14,7 @@
               <i class="fa fa-dashboard"></i> Home
             <% end %>
           </li>
-          <li class="breadcrumb-item"><%= link_to "Vendors", (vendors_path) %></li>
+          <li class="breadcrumb-item"><%= link_to "Vendors", vendors_path %></li>
           <li class="breadcrumb-item"><%= @vendor.contact_name %></li>
         </ol>
       </div>


### PR DESCRIPTION
Resolves #4240 

### Description

Refer to #4324 for original PR that is now split up into three parts.

Part 1 updates `routes.rb` to no longer use the `organization_name` scope. The controllers have also been updated to reflect this change

Part 2 contains changes to view files.

Part 3 contains changes to test files.

### Type of change

* New feature (non-breaking change which adds functionality) -> for users that are not super admins
* Breaking change (fix or feature that would cause existing functionality to not work as expected) -> super admins won’t be able to access routes outside of the `/admin` namespace (see Discussion section for #4324 )

### How Has This Been Tested?

Tests files have been updated under Part 3 (CI test suite will fail for Part 1 and Part 2).