### PR TITLE
Remove `organization_name` from base URL - Part 3: test files

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -89,8 +89,7 @@ RSpec.describe ApplicationController do
       let(:user) { create(:super_admin) }
 
       it "links to the general dashboard" do
-        org_name = @organization.short_name
-        expect(controller.dashboard_path_from_current_role).to eq "/#{org_name}/dashboard"
+        expect(controller.dashboard_path_from_current_role).to eq "/dashboard"
       end
     end
   end

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe DistributionsController, type: :controller do
-  let(:default_params) do
-    { organization_name: @organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(@user)

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -1,29 +1,25 @@
 RSpec.describe DonationSitesController, type: :controller do
-  let(:default_params) do
-    { organization_name: @organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(@user)
     end
 
     describe "GET #index" do
-      subject { get :index, params: default_params }
+      subject { get :index }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #new" do
-      subject { get :new, params: default_params }
+      subject { get :new }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #edit" do
-      subject { get :edit, params: default_params.merge(id: create(:donation_site, organization: @organization)) }
+      subject { get :edit, params: { id: create(:donation_site, organization: @organization) } }
       it "returns http success" do
         expect(subject).to be_successful
       end
@@ -35,7 +31,7 @@ RSpec.describe DonationSitesController, type: :controller do
     end
 
     describe "GET #show" do
-      subject { get :show, params: default_params.merge(id: create(:donation_site, organization: @organization)) }
+      subject { get :show, params: { id: create(:donation_site, organization: @organization) } }
       it "returns http success" do
         expect(subject).to be_successful
       end

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -1,7 +1,4 @@
 RSpec.describe DonationsController, type: :controller do
-  let(:default_params) do
-    { organization_name: @organization.to_param }
-  end
   let(:donation) { create(:donation, organization: @organization) }
 
   context "While signed in as a normal user >" do
@@ -10,14 +7,14 @@ RSpec.describe DonationsController, type: :controller do
     end
 
     describe "GET #index" do
-      subject { get :index, params: default_params }
+      subject { get :index }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #new" do
-      subject { get :new, params: default_params }
+      subject { get :new }
       it "returns http success" do
         expect(subject).to be_successful
       end
@@ -29,17 +26,17 @@ RSpec.describe DonationsController, type: :controller do
       let(:line_items) { [attributes_for(:line_item)] }
 
       it "redirects to GET#edit on success" do
-        post :create, params: default_params.merge(
+        post :create, params: {
           donation: { storage_location_id: storage_location.id,
                       donation_site_id: donation_site.id,
                       source: "Donation Site",
                       line_items: line_items }
-        )
+        }
         expect(response).to redirect_to(donations_path)
       end
 
       it "renders GET#new with error on failure" do
-        post :create, params: default_params.merge(donation: { storage_location_id: nil, donation_site_id: nil, source: nil })
+        post :create, params: { donation: { storage_location_id: nil, donation_site_id: nil, source: nil } }
         expect(response).to be_successful # Will render :new
         expect(response).to have_error(/error/i)
       end
@@ -48,7 +45,7 @@ RSpec.describe DonationsController, type: :controller do
     describe "PUT#update" do
       it "redirects to index after update" do
         donation = create(:donation_site_donation)
-        put :update, params: default_params.merge(id: donation.id, donation: { source: "Donation Site", donation_site_id: donation.donation_site_id })
+        put :update, params: { id: donation.id, donation: { source: "Donation Site", donation_site_id: donation.donation_site_id } }
         expect(response).to redirect_to(donations_path)
       end
 
@@ -65,7 +62,7 @@ RSpec.describe DonationsController, type: :controller do
         }
         donation_params = { source: donation.source, line_items_attributes: line_item_params }
         expect do
-          put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+          put :update, params: { id: donation.id, donation: donation_params }
         end.to change { donation.storage_location.inventory_items.first.quantity }.by(5)
           .and change {
                  View::Inventory.new(donation.organization_id)
@@ -89,7 +86,7 @@ RSpec.describe DonationsController, type: :controller do
           }
           donation_params = { storage_location_id: new_storage_location.id, line_items_attributes: line_item_params }
           expect do
-            put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+            put :update, params: { id: donation.id, donation: donation_params }
           end.to change { original_storage_location.size }.by(-10) # removes the whole donation of 10
           expect(new_storage_location.size).to eq 8
         end
@@ -117,7 +114,7 @@ RSpec.describe DonationsController, type: :controller do
             }
           }
           donation_params = { source: donation.source, storage_location: new_storage_location, line_items_attributes: line_item_params }
-          put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+          put :update, params: { id: donation.id, donation: donation_params }
           expect(response).not_to redirect_to(anything)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
@@ -138,7 +135,7 @@ RSpec.describe DonationsController, type: :controller do
           }
           donation_params = { source: donation.source, line_items_attributes: line_item_params }
           expect do
-            put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+            put :update, params: { id: donation.id, donation: donation_params }
           end.to change { donation.storage_location.inventory_items.first.quantity }.by(-10)
             .and change {
                    View::Inventory.new(donation.organization_id)
@@ -149,21 +146,21 @@ RSpec.describe DonationsController, type: :controller do
     end
 
     describe "GET #edit" do
-      subject { get :edit, params: default_params.merge(id: donation.id) }
+      subject { get :edit, params: { id: donation.id } }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #show" do
-      subject { get :show, params: default_params.merge(id: donation.id) }
+      subject { get :show, params: { id: donation.id } }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "DELETE #destroy" do
-      subject { delete :destroy, params: default_params.merge(id: donation.id) }
+      subject { delete :destroy, params: { id: donation.id } }
 
       # normal users are not authorized
       it "redirects to the dashboard path" do
@@ -178,7 +175,7 @@ RSpec.describe DonationsController, type: :controller do
     end
 
     describe "DELETE #destroy" do
-      subject { delete :destroy, params: default_params.merge(id: donation.id) }
+      subject { delete :destroy, params: { id: donation.id } }
       it "redirects to the index" do
         expect(subject).to redirect_to(donations_path)
       end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,29 +1,25 @@
 RSpec.describe ItemsController, type: :controller do
-  let(:default_params) do
-    { organization_name: @organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(@user)
     end
 
     describe "GET #index" do
-      subject { get :index, params: default_params }
+      subject { get :index }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #new" do
-      subject { get :new, params: default_params }
+      subject { get :new }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #edit" do
-      subject { get :edit, params: default_params.merge(id: create(:item, organization: @organization)) }
+      subject { get :edit, params: { id: create(:item, organization: @organization) } }
       it "returns http success" do
         expect(subject).to be_successful
       end
@@ -32,7 +28,7 @@ RSpec.describe ItemsController, type: :controller do
     describe "PUT #update" do
       context "visible" do
         let(:item) { create(:item, visible_to_partners: false) }
-        subject { put :update, params: default_params.merge(id: item.id, item: { value_in_cents: 100, visible_to_partners: true }) }
+        subject { put :update, params: { id: item.id, item: { value_in_cents: 100, visible_to_partners: true } } }
         it "should update visible_to_partners to true" do
           expect(subject).to redirect_to(items_path)
           expect(item.reload.visible_to_partners).to be true
@@ -41,7 +37,7 @@ RSpec.describe ItemsController, type: :controller do
 
       context "invisible" do
         let(:item) { create(:item, visible_to_partners: true) }
-        subject { put :update, params: default_params.merge(id: item.id, item: { value_in_cents: 100, visible_to_partners: false }) }
+        subject { put :update, params: { id: item.id, item: { value_in_cents: 100, visible_to_partners: false } } }
         it "should update visible_to_partners to false" do
           expect(subject).to redirect_to(items_path)
           expect(item.reload.visible_to_partners).to be false
@@ -50,14 +46,14 @@ RSpec.describe ItemsController, type: :controller do
     end
 
     describe "GET #show" do
-      subject { get :show, params: default_params.merge(id: create(:item, organization: @organization)) }
+      subject { get :show, params: { id: create(:item, organization: @organization) } }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "DELETE #destroy" do
-      subject { delete :destroy, params: default_params.merge(id: create(:item, organization: @organization)) }
+      subject { delete :destroy, params: { id: create(:item, organization: @organization) } }
       it "redirects to #index" do
         expect(subject).to redirect_to(items_path)
       end
@@ -69,7 +65,7 @@ RSpec.describe ItemsController, type: :controller do
 
         it "re-activates the item" do
           expect do
-            patch :restore, params: default_params.merge(id: item.id)
+            patch :restore, params: { id: item.id }
           end.to change { Item.active.size }.by(1)
         end
       end
@@ -78,7 +74,7 @@ RSpec.describe ItemsController, type: :controller do
         let!(:item) { create(:item, :active) }
         it "does nothing" do
           expect do
-            patch :restore, params: default_params.merge(id: item.id)
+            patch :restore, params: { id: item.id }
           end.to change { Item.active.size }.by(0)
         end
       end
@@ -87,7 +83,7 @@ RSpec.describe ItemsController, type: :controller do
         let!(:external_item) { create(:item, :inactive, organization: create(:organization)) }
         it "does nothing" do
           expect do
-            patch :restore, params: default_params.merge(id: external_item.id)
+            patch :restore, params: { id: external_item.id }
           end.to change { Item.active.size }.by(0)
         end
       end
@@ -109,19 +105,19 @@ RSpec.describe ItemsController, type: :controller do
       context "with valid params" do
         it "should create an item" do
           expect do
-            post :create, params: default_params.merge(item_params)
+            post :create, params: item_params
           end.to change { Item.count }.by(1)
         end
 
         it "should accept params with dollar signs, periods, and commas" do
           item_params["value_in_cents"] = "$5,432.10"
-          post :create, params: default_params.merge(item_params)
+          post :create, params: item_params
 
           expect(response).not_to have_error
         end
 
         it "should redirect to the item page" do
-          post :create, params: default_params.merge(item_params)
+          post :create, params: item_params
 
           expect(response).to redirect_to items_path
           expect(response).to have_notice
@@ -134,7 +130,7 @@ RSpec.describe ItemsController, type: :controller do
         end
 
         it "should show an error" do
-          post :create, params: default_params.merge(bad_params)
+          post :create, params: bad_params
 
           expect(response).to have_error
         end
@@ -151,14 +147,14 @@ RSpec.describe ItemsController, type: :controller do
       let!(:item) { create(:item, item_category: item_category) }
 
       it "should remove an item's category" do
-        patch :remove_category, params: default_params.merge(id: item.id)
+        patch :remove_category, params: { id: item.id }
         expect(item.reload.item_category).to be_nil
       end
 
       it "should redirect to the previous category page" do
-        patch :remove_category, params: default_params.merge(id: item.id)
+        patch :remove_category, params: { id: item.id }
 
-        expect(response).to redirect_to item_category_path(item_category)
+        expect(response).to redirect_to item_category_path(id: item_category.id)
         expect(response).to have_notice
       end
     end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TransfersController, type: :controller do
         travel_back
       end
 
-      subject { get :index, params: { organization_name: @organization.short_name } }
+      subject { get :index }
       it "returns http success" do
         expect(subject).to be_successful
       end
@@ -24,14 +24,14 @@ RSpec.describe TransfersController, type: :controller do
           it 'only returns the correct obejects' do
             start_date = 3.days.ago.to_formatted_s(:date_picker)
             end_date = Time.zone.today.to_formatted_s(:date_picker)
-            get :index, params: { organization_name: @organization.short_name, filters: { date_range: "#{start_date} - #{end_date}" } }
+            get :index, params: { filters: { date_range: "#{start_date} - #{end_date}" } }
             expect(assigns(:transfers)).to eq([new_transfer])
           end
         end
 
         context 'when date parameters are not supplied' do
           it 'returns all objects' do
-            get :index, params: { organization_name: @organization.short_name }
+            get :index
             expect(assigns(:transfers)).to eq([old_transfer, new_transfer])
           end
         end
@@ -47,12 +47,12 @@ RSpec.describe TransfersController, type: :controller do
           from_id: create(:storage_location, organization: @organization).id
         )
 
-        post :create, params: { organization_name: @organization.short_name, transfer: attributes }
+        post :create, params: { transfer: attributes }
         expect(response).to redirect_to(transfers_path)
       end
 
       it "renders to #new when failing" do
-        post :create, params: { organization_name: @organization.short_name, transfer: { from_id: nil, to_id: nil } }
+        post :create, params: { transfer: { from_id: nil, to_id: nil } }
         expect(response).to be_successful # Will render :new
         expect(response).to render_template("new")
         expect(flash.keys).to match_array(['error'])
@@ -60,14 +60,14 @@ RSpec.describe TransfersController, type: :controller do
     end
 
     describe "GET #new" do
-      subject { get :new, params: { organization_name: @organization.short_name } }
+      subject { get :new }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
 
     describe "GET #show" do
-      subject { get :show, params: { organization_name: @organization.short_name, id: create(:transfer, organization: @organization) } }
+      subject { get :show, params: { id: create(:transfer, organization: @organization) } }
       it "returns http success" do
         expect(subject).to be_successful
       end

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe OrganizationMailer, type: :mailer, skip_seed: true do
       html = html_body(subject)
       expect(html).to include("<h1> You've received a request to approve the account for #{partner.name}. </h1>")
       expect(html).to include("Review This Partner")
-      expect(html).to include("#{organization.short_name}/partners/#{partner.id}#partner-information\">Review This Partner</a>")
+      expect(html).to include("/partners/#{partner.id}#partner-information\">Review This Partner</a>")
       text = text_body(subject)
       expect(text).to include("You've received a request to approve the account for #{partner.name}.")
       expect(text).to include("Review This Partner")
-      expect(text).to include("#{organization.short_name}/partners/#{partner.id}#partner-information")
+      expect(text).to include("/partners/#{partner.id}#partner-information")
     end
 
     it "includes a link to the relevant partner" do
-      expect(subject.body.encoded).to include("/#{organization.short_name}/partners/#{partner.id}#partner-information")
+      expect(subject.body.encoded).to include("/partners/#{partner.id}#partner-information")
     end
 
     it "should be sent to the partner main email with the correct subject line" do

--- a/spec/requests/adjustments_requests_spec.rb
+++ b/spec/requests/adjustments_requests_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Adjustments", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   # This should return the minimal set of attributes required to create a valid
   # Adjustment. As you add validations to Adjustment, be sure to
   # adjust the attributes here as well.
@@ -36,7 +32,7 @@ RSpec.describe "Adjustments", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get adjustments_path(default_params.merge(format: response_format))
+        get adjustments_path(format: response_format)
         response
       end
 
@@ -60,14 +56,14 @@ RSpec.describe "Adjustments", type: :request, skip_seed: true do
 
           context 'when date parameters are supplied' do
             it 'only returns the correct objects' do
-              get adjustments_path(default_params.merge(filters: { date_range: date_range_picker_params(3.days.ago, Time.zone.today) }))
+              get adjustments_path(filters: { date_range: date_range_picker_params(3.days.ago, Time.zone.today) })
               expect(assigns(:adjustments)).to contain_exactly(new_adjustment)
             end
           end
 
           context 'when date parameters are not supplied' do
             it 'returns all objects' do
-              get adjustments_path(default_params)
+              get adjustments_path
               expect(assigns(:adjustments)).to contain_exactly(old_adjustment, new_adjustment)
             end
           end
@@ -85,7 +81,7 @@ RSpec.describe "Adjustments", type: :request, skip_seed: true do
 
     describe "GET #show" do
       subject do
-        get adjustment_path(adjustment, default_params)
+        get adjustment_path(adjustment)
         response
       end
 
@@ -94,7 +90,7 @@ RSpec.describe "Adjustments", type: :request, skip_seed: true do
 
     describe "GET #new" do
       it "is successful" do
-        get new_adjustment_path(default_params)
+        get new_adjustment_path
         expect(response).to be_successful
       end
     end
@@ -103,36 +99,36 @@ RSpec.describe "Adjustments", type: :request, skip_seed: true do
       context "with valid params" do
         it "creates a new Adjustment" do
           expect do
-            post adjustments_path(default_params.merge(adjustment: valid_attributes))
+            post adjustments_path(adjustment: valid_attributes)
           end.to change(Adjustment, :count).by(1)
             .and change(AdjustmentEvent, :count).by(1)
         end
 
         it "assigns a newly created adjustment as @adjustment" do
-          post adjustments_path(default_params.merge(adjustment: valid_attributes))
+          post adjustments_path(adjustment: valid_attributes)
           expect(assigns(:adjustment)).to be_a(Adjustment)
           expect(assigns(:adjustment)).to be_persisted
         end
 
         it "assigns a user id from the current user" do
-          post adjustments_path(default_params.merge(adjustment: valid_attributes))
+          post adjustments_path(adjustment: valid_attributes)
           expect(assigns(:adjustment).user_id).to eq(user.id)
         end
 
         it "redirects to the #show after created adjustment" do
-          post adjustments_path(default_params.merge(adjustment: valid_attributes))
+          post adjustments_path(adjustment: valid_attributes)
           expect(response).to redirect_to(adjustment_path(Adjustment.last))
         end
       end
 
       context "with invalid params" do
         it "assigns a newly created but unsaved adjustment as @adjustment" do
-          post adjustments_path(default_params.merge(adjustment: invalid_attributes))
+          post adjustments_path(adjustment: invalid_attributes)
           expect(assigns(:adjustment)).to be_a_new(Adjustment)
         end
 
         it "re-renders the 'new' template" do
-          post adjustments_path(default_params.merge(adjustment: invalid_attributes))
+          post adjustments_path(adjustment: invalid_attributes)
           expect(response).to render_template("new")
         end
       end

--- a/spec/requests/admin/broadcast_announcements_spec.rb
+++ b/spec/requests/admin/broadcast_announcements_spec.rb
@@ -121,14 +121,14 @@ RSpec.describe "BroadcastAnnouncements", type: :request, skip_seed: true do
     describe "GET /new" do
       it "redirects" do
         get new_admin_broadcast_announcement_url
-        expect(response).to redirect_to(dashboard_path(organization_name: organization_admin.organization))
+        expect(response).to redirect_to(dashboard_path)
       end
     end
 
     describe "POST /create" do
       it "redirects" do
         post admin_broadcast_announcements_url, params: {user: user.id, message: "test"}
-        expect(response).to redirect_to(dashboard_path(organization_name: organization_admin.organization))
+        expect(response).to redirect_to(dashboard_path)
       end
     end
   end

--- a/spec/requests/admin/users_requests_spec.rb
+++ b/spec/requests/admin/users_requests_spec.rb
@@ -144,14 +144,14 @@ RSpec.describe "Admin::UsersController", type: :request do
     describe "GET #new" do
       it "redirects" do
         get new_admin_user_path
-        expect(response).to redirect_to(dashboard_path(organization_name: @organization_admin.organization))
+        expect(response).to redirect_to(dashboard_path)
       end
     end
 
     describe "POST #create" do
       it "redirects" do
         post admin_users_path, params: { user: { organization_id: @organization.id } }
-        expect(response).to redirect_to(dashboard_path(organization_name: @organization_admin.organization))
+        expect(response).to redirect_to(dashboard_path)
       end
     end
   end
@@ -165,14 +165,14 @@ RSpec.describe "Admin::UsersController", type: :request do
     describe "GET #new" do
       it "redirects" do
         get new_admin_user_path
-        expect(response).to redirect_to(dashboard_path(organization_name: @user.organization))
+        expect(response).to redirect_to(dashboard_path)
       end
     end
 
     describe "POST #create" do
       it "redirects" do
         post admin_users_path, params: { user: { organization_id: @organization.id } }
-        expect(response).to redirect_to(dashboard_path(organization_name: @user.organization))
+        expect(response).to redirect_to(dashboard_path)
       end
     end
   end

--- a/spec/requests/admin_requests_spec.rb
+++ b/spec/requests/admin_requests_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Admin", type: :request, skip_seed: true do
       [organization_admin, user].each do |u|
         sign_in(u)
         get admin_dashboard_path
-        expect(response).to redirect_to(dashboard_path(organization_name: u.organization))
+        expect(response).to redirect_to(dashboard_path)
         expect(response).to have_error
       end
     end

--- a/spec/requests/audits_requests_spec.rb
+++ b/spec/requests/audits_requests_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   let(:valid_attributes) do
     {
       organization_id: organization.id,
@@ -38,7 +34,7 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
     describe "GET #index" do
       it "is successful" do
         Audit.create! valid_attributes
-        get audits_path(default_params)
+        get audits_path
         expect(response).to be_successful
       end
     end
@@ -46,14 +42,14 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
     describe "GET #show" do
       it "is successful" do
         audit = create(:audit, organization: organization)
-        get audits_path(default_params.merge(id: audit.to_param))
+        get audits_path(id: audit.to_param)
         expect(response).to be_successful
       end
     end
 
     describe "GET #new" do
       it "is successful" do
-        get new_audit_path(default_params)
+        get new_audit_path
         expect(response).to be_successful
       end
     end
@@ -61,17 +57,17 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
     describe "GET #edit" do
       it "is successful if the status of audit is `in_progress`" do
         audit = create(:audit, organization: organization)
-        get edit_audit_path(default_params.merge(id: audit.to_param))
+        get edit_audit_path(id: audit.to_param)
         expect(response).to be_successful
       end
 
       it "redirects to #index if the status of audit is not `in_progress`" do
         audit = create(:audit, organization: organization, status: :confirmed)
-        get edit_audit_path(default_params.merge(id: audit.to_param))
+        get edit_audit_path(id: audit.to_param)
         expect(response).to redirect_to(audits_path)
 
         audit = create(:audit, organization: organization, status: :finalized)
-        get edit_audit_path(default_params.merge(id: audit.to_param))
+        get edit_audit_path(id: audit.to_param)
         expect(response).to redirect_to(audits_path)
       end
     end
@@ -80,49 +76,49 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
       context "with valid params" do
         it "creates a new Audit" do
           expect do
-            post audits_path(default_params.merge(audit: valid_attributes))
+            post audits_path(audit: valid_attributes)
           end.to change(Audit, :count).by(1)
         end
 
         it "creates a new Audit with status as `in_progress` if `save_progress` is passed as a param" do
           expect do
-            post audits_path(default_params.merge(audit: valid_attributes, save_progress: ''))
+            post audits_path(audit: valid_attributes, save_progress: '')
             expect(Audit.last.in_progress?).to be_truthy
           end.to change(Audit.in_progress, :count).by(1)
         end
 
         it "creates a new Audit with status as `confirmed` if `confirm_audit` is passed as a param" do
           expect do
-            post audits_path(default_params.merge(audit: valid_attributes, confirm_audit: ''))
+            post audits_path(audit: valid_attributes, confirm_audit: '')
             expect(Audit.last.confirmed?).to be_truthy
           end.to change(Audit.confirmed, :count).by(1)
         end
 
         it "assigns a newly created audit as @audit" do
-          post audits_path(default_params.merge(audit: valid_attributes))
+          post audits_path(audit: valid_attributes)
           expect(assigns(:audit)).to be_a(Audit)
           expect(assigns(:audit)).to be_persisted
         end
 
         it "redirects to the #show after created audit" do
-          post audits_path(default_params.merge(audit: valid_attributes))
+          post audits_path(audit: valid_attributes)
           expect(response).to redirect_to(audit_path(Audit.last))
         end
       end
 
       context "with invalid params" do
         it "assigns a newly created but unsaved audit as @audit" do
-          post audits_path(default_params.merge(audit: invalid_attributes))
+          post audits_path(audit: invalid_attributes)
           expect(assigns(:audit)).to be_a_new(Audit)
         end
 
         it "re-renders the 'new' template" do
-          post audits_path(default_params.merge(audit: invalid_attributes))
+          post audits_path(audit: invalid_attributes)
           expect(response).to render_template(:new)
         end
 
         it "re-renders the 'new' template with an error message when an invalid storage location is given" do
-          post audits_path(default_params.merge(audit: invalid_storage_location_attributes))
+          post audits_path(audit: invalid_storage_location_attributes)
           expect(response).to render_template(:new)
           expect(flash[:error]).to eq("Storage location must exist")
         end
@@ -133,7 +129,7 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
       it 'sets the finalize status and saves an event' do
         audit = create(:audit, organization: organization)
         expect(AuditEvent.count).to eq(0)
-        post audit_finalize_path(default_params.merge(audit_id: audit.to_param))
+        post audit_finalize_path(audit_id: audit.to_param)
         expect(audit.reload).to be_finalized
         expect(AuditEvent.count).to eq(1)
       end
@@ -144,21 +140,21 @@ RSpec.describe "Audits", type: :request, skip_seed: true do
         it "destroys the audit if the audit's status is `in_progress`" do
           audit = create(:audit, organization: organization)
           expect do
-            delete audit_path(default_params.merge(id: audit.to_param))
+            delete audit_path(id: audit.to_param)
           end.to change(Audit, :count).by(-1)
         end
 
         it "destroys the audit if the audit's status is `confirms`" do
           audit = create(:audit, organization: organization, status: :confirmed)
           expect do
-            delete audit_path(default_params.merge(id: audit.to_param))
+            delete audit_path(id: audit.to_param)
           end.to change(Audit, :count).by(-1)
         end
 
         it "can not destroy the audit if the audit's status is `finalized`" do
           audit = create(:audit, organization: organization, status: :finalized)
           expect do
-            delete audit_path(default_params.merge(id: audit.to_param))
+            delete audit_path(id: audit.to_param)
           end.to change(Audit, :count).by(0)
         end
       end

--- a/spec/requests/barcode_items_requests_spec.rb
+++ b/spec/requests/barcode_items_requests_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe "BarcodeItems", type: :request do
-  let(:default_params) do
-    { organization_name: @organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(@user)
@@ -10,7 +6,7 @@ RSpec.describe "BarcodeItems", type: :request do
 
     describe "GET #index" do
       subject do
-        get barcode_items_path(default_params.merge(format: response_format))
+        get barcode_items_path(format: response_format)
         response
       end
 
@@ -31,7 +27,7 @@ RSpec.describe "BarcodeItems", type: :request do
 
     describe "GET #new" do
       it "returns http success" do
-        get new_barcode_item_path(default_params)
+        get new_barcode_item_path
         expect(response).to be_successful
       end
     end
@@ -39,14 +35,14 @@ RSpec.describe "BarcodeItems", type: :request do
     describe "GET #edit" do
       context "with a normal barcode item" do
         it "returns http success" do
-          get edit_barcode_item_path(default_params.merge(id: create(:barcode_item)))
+          get edit_barcode_item_path(id: create(:barcode_item))
           expect(response).to be_successful
         end
       end
 
       context "with a global barcode item" do
         it "returns a 404" do
-          get edit_barcode_item_path(default_params.merge(id: create(:global_barcode_item)))
+          get edit_barcode_item_path(id: create(:global_barcode_item))
           expect(response.status).to eq(404)
         end
       end
@@ -55,14 +51,14 @@ RSpec.describe "BarcodeItems", type: :request do
     describe "GET #show" do
       context "with a normal barcode item" do
         it "returns http success" do
-          get barcode_item_path(default_params.merge(id: create(:barcode_item)))
+          get barcode_item_path(id: create(:barcode_item))
           expect(response).to be_successful
         end
       end
 
       context "with a global barcode item" do
         it "returns a 404" do
-          get barcode_item_path(default_params.merge(id: create(:global_barcode_item)))
+          get barcode_item_path(id: create(:global_barcode_item))
           expect(response.status).to eq(404)
         end
       end
@@ -75,7 +71,7 @@ RSpec.describe "BarcodeItems", type: :request do
 
       context "via ajax" do
         it "can find a barcode that is scoped to just this organization" do
-          get find_barcode_items_path(default_params.merge(barcode_item: { value: organization_barcode.value }, format: :json))
+          get find_barcode_items_path(barcode_item: { value: organization_barcode.value }, format: :json)
           expect(response).to be_successful
           result = JSON.parse(response.body)
           expect(result["barcode_item"]["barcodeable_type"]).to eq("Item")
@@ -83,7 +79,7 @@ RSpec.describe "BarcodeItems", type: :request do
         end
 
         it "can find a barcode that's universally available" do
-          get find_barcode_items_path(default_params.merge(barcode_item: { value: global_barcode.value }, format: :json))
+          get find_barcode_items_path(barcode_item: { value: global_barcode.value }, format: :json)
           expect(response).to be_successful
           result = JSON.parse(response.body)
           expect(result["barcode_item"]["barcodeable_type"]).to eq("BaseItem")
@@ -92,7 +88,7 @@ RSpec.describe "BarcodeItems", type: :request do
 
         context "when it's missing" do
           it "returns a 404" do
-            get find_barcode_items_path(default_params.merge(barcode_item: { value: other_barcode.value }, format: :json))
+            get find_barcode_items_path(barcode_item: { value: other_barcode.value }, format: :json)
             expect(response.status).to eq(404)
           end
         end
@@ -103,7 +99,7 @@ RSpec.describe "BarcodeItems", type: :request do
       it "disallows a user to delete someone else's barcode" do
         other_org = create(:organization)
         other_barcode = create(:barcode_item, organization_id: other_org.id)
-        delete barcode_item_path(default_params.merge(id: other_barcode.to_param))
+        delete barcode_item_path(id: other_barcode.to_param)
         expect(response).not_to be_successful
         expect(response).to have_error(/permission/)
       end
@@ -112,13 +108,13 @@ RSpec.describe "BarcodeItems", type: :request do
         allow_any_instance_of(User).to receive(:has_role?).with(Role::SUPER_ADMIN).and_return(false)
         allow_any_instance_of(User).to receive(:has_role?).with(Role::ORG_USER, anything).and_return(true)
         global_barcode = create(:global_barcode_item)
-        delete barcode_item_path(default_params.merge(id: global_barcode.to_param))
+        delete barcode_item_path(id: global_barcode.to_param)
         expect(response).not_to be_successful
         expect(response).to have_error(/permission/)
       end
 
       it "redirects to the index" do
-        delete barcode_item_path(default_params.merge(id: create(:barcode_item, organization_id: @organization.id)))
+        delete barcode_item_path(id: create(:barcode_item, organization_id: @organization.id))
         expect(subject).to redirect_to(barcode_items_path)
       end
     end

--- a/spec/requests/dashboard_requests_spec.rb
+++ b/spec/requests/dashboard_requests_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "Dashboard", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(user)
@@ -15,7 +11,7 @@ RSpec.describe "Dashboard", type: :request, skip_seed: true do
 
     describe "GET #show" do
       it "returns http success" do
-        get dashboard_path(default_params)
+        get dashboard_path
         expect(response).to be_successful
         expect(response.body).not_to include('switch_to_partner_role')
       end
@@ -24,7 +20,7 @@ RSpec.describe "Dashboard", type: :request, skip_seed: true do
         it 'should include the switch link' do
           partner = FactoryBot.create(:partner)
           user.add_role(Role::PARTNER, partner)
-          get dashboard_path(default_params)
+          get dashboard_path
           expect(response.body).to include('switch_to_role')
         end
       end
@@ -41,13 +37,13 @@ RSpec.describe "Dashboard", type: :request, skip_seed: true do
     context "BroadcastAnnouncement card" do
       it "displays announcements if there are valid ones" do
         BroadcastAnnouncement.create(message: "test announcement", user_id: user.id, organization_id: nil)
-        get dashboard_path(default_params)
+        get dashboard_path
         expect(response.body).to include("test announcement")
       end
 
       it "doesn't display announcements if they are not from super admins" do
         BroadcastAnnouncement.create(message: "test announcement", user_id: user.id, organization_id: organization.id)
-        get dashboard_path(default_params)
+        get dashboard_path
         expect(response.body).not_to include("test announcement")
       end
     end
@@ -55,7 +51,7 @@ RSpec.describe "Dashboard", type: :request, skip_seed: true do
 
   context "While not signed in" do
     it "redirects for authentication" do
-      get dashboard_path(organization_name: create(:organization).to_param)
+      get dashboard_path
       expect(response).to be_redirect
     end
   end

--- a/spec/requests/distributions_by_county_spec.rb
+++ b/spec/requests/distributions_by_county_spec.rb
@@ -1,15 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "DistributionsByCounties", type: :request, skip_seed: true do
-  let(:default_params) do
-    {organization_name: organization.to_param}
-  end
-
   include_examples "distribution_by_county"
 
   context "While not signed in" do
     it "redirects for authentication" do
-      get distributions_by_county_report_path(default_params)
+      get distributions_by_county_report_path
       expect(response).to be_redirect
     end
 
@@ -20,7 +16,7 @@ RSpec.describe "DistributionsByCounties", type: :request, skip_seed: true do
 
       it "shows 'Unspecified 100%' if no served_areas" do
         create(:distribution, :with_items, item: item_1, organization: organization)
-        get distributions_by_county_report_path(default_params)
+        get distributions_by_county_report_path
         expect(response.body).to include("Unspecified")
         expect(response.body).to include("100")
         expect(response.body).to include("$1,050.00")
@@ -31,7 +27,7 @@ RSpec.describe "DistributionsByCounties", type: :request, skip_seed: true do
           create(:distribution, :with_items, item: item_1, organization: organization, partner: partner_1, issued_at: issued_at_present)
           create(:distribution, :with_items, item: item_1, organization: organization, partner: partner_2, issued_at: issued_at_present)
 
-          get distributions_by_county_report_path(default_params)
+          get distributions_by_county_report_path
 
           expect(response.body).to include("45") # First ones are definitely combined
           expect(response.body).to include("$472.50")

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
   let(:user) { create(:user, organization: organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   let(:secret_key) { "HI MOM THIS IS ME AND I'M CODING" }
   let(:crypt) { ActiveSupport::MessageEncryptor.new(secret_key) }
   let(:hashed_id) { CGI.escape(crypt.encrypt_and_sign(organization.id)) }
@@ -30,7 +26,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       end
 
       it "returns http success" do
-        get itemized_breakdown_distributions_path(default_params.merge(format: :csv))
+        get itemized_breakdown_distributions_path(format: :csv)
 
         expect(response).to be_successful
         expect(response.body).to eq(fake_csv)
@@ -39,7 +35,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
     describe "GET #print" do
       it "returns http success" do
-        get print_distribution_path(default_params.merge(id: create(:distribution).id))
+        get print_distribution_path(id: create(:distribution).id)
         expect(response).to be_successful
       end
 
@@ -47,7 +43,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
         let(:non_utf8_partner) { create(:partner, name: "KOKA Keiki O Ka ‘Āina") }
 
         it "returns http success" do
-          get print_distribution_path(default_params.merge(id: create(:distribution, partner: non_utf8_partner).id))
+          get print_distribution_path(id: create(:distribution, partner: non_utf8_partner).id)
           expect(response).to be_successful
         end
       end
@@ -55,7 +51,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
     describe "GET #reclaim" do
       it "returns http success" do
-        get distributions_path(default_params.merge(organization_name: organization, id: create(:distribution).id))
+        get distributions_path(id: create(:distribution).id)
         expect(response).to be_successful
       end
     end
@@ -65,23 +61,23 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       let!(:distribution) { create(:distribution, :with_items, :past, item: item, item_quantity: 10, organization: organization) }
 
       it "returns http success" do
-        get distributions_path(default_params)
+        get distributions_path
         expect(response).to be_successful
       end
 
       it "sums distribution totals accurately" do
         create(:distribution, :with_items, item_quantity: 5, organization: organization)
         create(:line_item, :distribution, itemizable_id: distribution.id, quantity: 7)
-        get distributions_path(default_params)
+        get distributions_path
         expect(assigns(:total_items_all_distributions)).to eq(22)
         expect(assigns(:total_items_paginated_distributions)).to eq(22)
       end
 
       it "shows an enabled edit and reclaim button" do
-        get distributions_path(default_params)
+        get distributions_path
         page = Nokogiri::HTML(response.body)
-        edit = page.at_css("a[href='#{edit_distribution_path(default_params.merge(id: distribution.id))}']")
-        reclaim = page.at_css("a.btn-danger[href='#{distribution_path(default_params.merge(id: distribution.id))}']")
+        edit = page.at_css("a[href='#{edit_distribution_path(id: distribution.id)}']")
+        reclaim = page.at_css("a.btn-danger[href='#{distribution_path(id: distribution.id)}']")
         expect(edit.attr("class")).not_to match(/disabled/)
         expect(reclaim.attr("class")).not_to match(/disabled/)
         expect(response.body).not_to match(/Has Inactive Items/)
@@ -93,10 +89,10 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
         end
 
         it "shows a disabled edit and reclaim button" do
-          get distributions_path(default_params)
+          get distributions_path
           page = Nokogiri::HTML(response.body)
-          edit = page.at_css("a[href='#{edit_distribution_path(default_params.merge(id: distribution.id))}']")
-          reclaim = page.at_css("a.btn-danger[href='#{distribution_path(default_params.merge(id: distribution.id))}']")
+          edit = page.at_css("a[href='#{edit_distribution_path(id: distribution.id)}']")
+          reclaim = page.at_css("a.btn-danger[href='#{distribution_path(id: distribution.id)}']")
           expect(edit.attr("class")).to match(/disabled/)
           expect(reclaim.attr("class")).to match(/disabled/)
           expect(response.body).to match(/Has Inactive Items/)
@@ -108,16 +104,15 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       let!(:storage_location) { create(:storage_location, organization: organization) }
       let!(:partner) { create(:partner, organization: organization) }
       let(:distribution) do
-        { distribution: { storage_location_id: storage_location.id, partner_id: partner.id, delivery_method: :delivery } }
+        { storage_location_id: storage_location.id, partner_id: partner.id, delivery_method: :delivery }
       end
 
       it "redirects to #show on success" do
-        params = default_params.merge(distribution)
         expect(storage_location).to be_valid
         expect(partner).to be_valid
 
         expect(PartnerMailerJob).to receive(:perform_later).once
-        post distributions_path(params.merge(format: :turbo_stream))
+        post distributions_path(distribution:, format: :turbo_stream)
 
         expect(response).to have_http_status(:redirect)
         last_distribution = Distribution.last
@@ -125,7 +120,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       end
 
       it "renders #new again on failure, with notice" do
-        post distributions_path(default_params.merge(distribution: { comment: nil, partner_id: nil, storage_location_id: nil }, format: :turbo_stream))
+        post distributions_path(distribution: { comment: nil, partner_id: nil, storage_location_id: nil }, format: :turbo_stream)
         expect(response).to have_http_status(400)
         expect(response).to have_error
       end
@@ -135,7 +130,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       let!(:partner) { create(:partner, organization: organization) }
       let(:request) { create(:request, partner: partner, organization: organization) }
       let(:storage_location) { create(:storage_location, :with_items, organization: organization) }
-      let(:default_params) { { organization_name: organization.to_param, request_id: request.id } }
+      let(:default_params) { { request_id: request.id } }
 
       it "returns http success" do
         get new_distribution_path(default_params)
@@ -186,7 +181,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
           item_id: item.id,
           quantity: item_quantity
         )
-        get distribution_path(default_params.merge(id: distribution.id))
+        get distribution_path(id: distribution.id)
 
         expect(response).to be_successful
         expect(assigns(:total_quantity)).to eq(item_quantity + 1)
@@ -194,9 +189,9 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       end
 
       it "shows an enabled edit button" do
-        get distribution_path(default_params.merge(id: distribution.id))
+        get distribution_path(id: distribution.id)
         page = Nokogiri::HTML(response.body)
-        edit = page.at_css("a[href='#{edit_distribution_path(default_params.merge(id: distribution.id))}']")
+        edit = page.at_css("a[href='#{edit_distribution_path(id: distribution.id)}']")
         expect(edit.attr("class")).not_to match(/disabled/)
         expect(response.body).not_to match(/please make the following items active:/)
       end
@@ -207,9 +202,9 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
         end
 
         it "shows a disabled edit button" do
-          get distribution_path(default_params.merge(id: distribution.id))
+          get distribution_path(id: distribution.id)
           page = Nokogiri::HTML(response.body)
-          edit = page.at_css("a[href='#{edit_distribution_path(default_params.merge(id: distribution.id))}']")
+          edit = page.at_css("a[href='#{edit_distribution_path(id: distribution.id)}']")
           expect(edit.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
         end
@@ -218,17 +213,17 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
     describe "GET #schedule" do
       it "returns http success" do
-        get schedule_distributions_path(default_params)
+        get schedule_distributions_path
         expect(response).to be_successful
         page = Nokogiri::HTML(response.body)
         url = page.at_css('#copy-calendar-button').attributes['data-url'].value
-        hash = url.match(/\?hash=(.*)&/)[1]
+        hash = url.match(/\?hash=(.*)/)[1]
         expect(crypt.decrypt_and_verify(CGI.unescape(hash))).to eq(organization.id)
       end
     end
 
     describe 'PATCH #picked_up' do
-      subject { patch picked_up_distribution_path(default_params.merge(id: distribution.id)) }
+      subject { patch picked_up_distribution_path(id: distribution.id) }
 
       context 'when the distribution is successfully updated' do
         let(:distribution) { create(:distribution, state: :scheduled, organization: organization) }
@@ -246,7 +241,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
     describe "GET #pickup_day" do
       it "returns http success" do
-        get pickup_day_distributions_path(default_params)
+        get pickup_day_distributions_path
         expect(response).to be_successful
       end
 
@@ -258,7 +253,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
         create(:line_item, :distribution, item_id: first_item.id, itemizable_id: first_distribution.id, quantity: 7)
         create(:line_item, :distribution, item_id: first_item.id, itemizable_id: second_distribution.id, quantity: 4)
         create(:line_item, :distribution, item_id: second_item.id, itemizable_id: second_distribution.id, quantity: 5)
-        get pickup_day_distributions_path(default_params)
+        get pickup_day_distributions_path
         expect(assigns(:daily_items).detect { |item| item[:name] == first_item.name }[:quantity]).to eq(11)
         expect(assigns(:daily_items).detect { |item| item[:name] == second_item.name }[:quantity]).to eq(5)
         expect(assigns(:daily_items).sum { |item| item[:quantity] }).to eq(16)
@@ -273,7 +268,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
         create(:line_item, :distribution, item_id: first_item.id, itemizable_id: first_distribution.id, quantity: 7)
         create(:line_item, :distribution, item_id: first_item.id, itemizable_id: second_distribution.id, quantity: 4)
         create(:line_item, :distribution, item_id: second_item.id, itemizable_id: second_distribution.id, quantity: 6)
-        get pickup_day_distributions_path(default_params)
+        get pickup_day_distributions_path
         expect(assigns(:daily_items).detect { |item| item[:name] == first_item.name }[:package_count]).to eq(5)
         expect(assigns(:daily_items).detect { |item| item[:name] == second_item.name }[:package_count]).to eq(2)
         expect(assigns(:daily_items).sum { |item| item[:package_count] }).to eq(7)
@@ -292,16 +287,14 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       let(:distribution) { create(:distribution, partner: partner, organization: organization) }
       let(:issued_at) { distribution.issued_at }
       let(:distribution_params) do
-        default_params.merge(
-          id: distribution.id,
+        { id: distribution.id,
           distribution: {
             partner_id: partner.id,
             storage_location_id: location.id,
             'issued_at(1i)' => issued_at.to_date.year,
             'issued_at(2i)' => issued_at.to_date.month,
             'issued_at(3i)' => issued_at.to_date.day
-          }
-        )
+          }}
       end
 
       it "returns a 200" do
@@ -327,7 +320,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
           }
           distribution_params = { storage_location_id: new_storage_location.id, line_items_attributes: line_item_params }
           expect do
-            put distribution_path(default_params.merge(id: distribution.id, distribution: distribution_params))
+            put distribution_path(id: distribution.id, distribution: distribution_params)
           end.to change { original_storage_location.size }.by(10) # removes the whole distribution of 10 - increasing inventory
           expect(new_storage_location.size).to eq 25
         end
@@ -356,7 +349,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
           }
           distribution_params = { storage_location_id: new_storage_location.id, line_items_attributes: line_item_params }
           expect do
-            put :update, params: default_params.merge(id: donation.id, distribution: distribution_params)
+            put :update, params: { id: donation.id, distribution: distribution_params }
           end.to raise_error(NameError)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
@@ -397,7 +390,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       let(:distribution) { create(:distribution, partner: partner) }
 
       it "should show the distribution" do
-        get edit_distribution_path(default_params.merge(id: distribution.id))
+        get edit_distribution_path(id: distribution.id)
         expect(response).to be_successful
         expect(response.body).not_to include("You’ve had an audit since this distribution was started.")
       end
@@ -405,14 +398,14 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
       it "should show a warning if there is an inteverning audit" do
         distribution.update!(created_at: 1.week.ago)
         create(:audit, storage_location: distribution.storage_location, organization: organization)
-        get edit_distribution_path(default_params.merge(id: distribution.id))
+        get edit_distribution_path(id: distribution.id)
         expect(response.body).to include("You’ve had an audit since this distribution was started.")
       end
 
       it "should not show a warning if the audit is for another location" do
         distribution.update!(created_at: 1.week.ago)
         create(:audit, storage_location: create(:storage_location))
-        get edit_distribution_path(default_params.merge(id: distribution.id))
+        get edit_distribution_path(id: distribution.id)
         expect(response.body).not_to include("You’ve had an audit since this distribution was started.")
       end
     end
@@ -431,7 +424,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
       context 'with a correct hash id' do
         it 'should render the calendar' do
-          get distributions_calendar_path(hash: hashed_id)
+          get calendar_distributions_path(hash: hashed_id)
           expect(CalendarService).to have_received(:calendar).with(organization.id)
           expect(response.media_type).to include('text/calendar')
           expect(response.body).to eq('SOME ICS STRING')
@@ -440,7 +433,7 @@ RSpec.describe "Distributions", type: :request, skip_seed: true do
 
       context 'without a correct hash id' do
         it 'should error unauthorized' do
-          get distributions_calendar_path(hash: 'some-wrong-id')
+          get calendar_distributions_path(hash: 'some-wrong-id')
           expect(response.status).to eq(401)
         end
       end

--- a/spec/requests/donation_sites_requests_spec.rb
+++ b/spec/requests/donation_sites_requests_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "DonationSites", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   describe "while signed in" do
     before do
       sign_in(user)
@@ -15,7 +11,7 @@ RSpec.describe "DonationSites", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get donation_sites_path(default_params.merge(format: response_format))
+        get donation_sites_path(format: response_format)
         response
       end
 
@@ -40,11 +36,11 @@ RSpec.describe "DonationSites", type: :request, skip_seed: true do
       let!(:inactive_donation_site) { create(:donation_site, organization: organization, active: false, name: "An Inactive Site") }
 
       it "should show all/only active donation sites with deactivate buttons" do
-        get donation_sites_path(default_params)
+        get donation_sites_path
         page = Nokogiri::HTML(response.body)
         expect(response.body).to include("An Active Site")
         expect(response.body).not_to include("An Inactive Site")
-        button1 = page.css(".btn[href='/#{organization.short_name}/donation_sites/#{active_donation_site.id}/deactivate']")
+        button1 = page.css(".btn[href='/donation_sites/#{active_donation_site.id}/deactivate']")
         expect(button1.text.strip).to eq("Deactivate")
         expect(button1.attr('class')).not_to match(/disabled/)
       end
@@ -53,7 +49,7 @@ RSpec.describe "DonationSites", type: :request, skip_seed: true do
     describe 'DELETE #deactivate' do
       it 'should be able to deactivate an item' do
         donation_site = create(:donation_site, organization: organization, active: true, name: "to be deactivated")
-        params = default_params.merge(id: donation_site.id)
+        params = { id: donation_site.id }
 
         expect { delete deactivate_donation_site_path(params) }.to change { donation_site.reload.active }.from(true).to(false)
         expect(response).to redirect_to(donation_sites_path)

--- a/spec/requests/donations_requests_spec.rb
+++ b/spec/requests/donations_requests_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
   let(:user) { create(:user, organization: organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   describe "while signed in" do
     before do
       sign_in(user)
@@ -16,7 +12,7 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get donations_path(default_params.merge(format: response_format))
+        get donations_path(format: response_format)
         response
       end
 
@@ -92,9 +88,9 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
       let!(:donation) { create(:donation, :with_items, item: item) }
 
       it "shows an enabled edit button" do
-        get donation_path(default_params.merge(id: donation.id))
+        get donation_path(id: donation.id)
         page = Nokogiri::HTML(response.body)
-        edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
+        edit = page.at_css("a[href='#{edit_donation_path(id: donation.id)}']")
         expect(edit.attr("class")).not_to match(/disabled/)
         expect(response.body).not_to match(/please make the following items active:/)
       end
@@ -105,9 +101,9 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
         end
 
         it "shows a disabled edit button" do
-          get donation_path(default_params.merge(id: donation.id))
+          get donation_path(id: donation.id)
           page = Nokogiri::HTML(response.body)
-          edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
+          edit = page.at_css("a[href='#{edit_donation_path(id: donation.id)}']")
           expect(edit.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
         end
@@ -120,10 +116,10 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
         end
 
         it "shows a disabled edit and delete buttons" do
-          get donation_path(default_params.merge(id: donation.id))
+          get donation_path(donation.id)
           page = Nokogiri::HTML(response.body)
-          edit = page.at_css("a[href='#{edit_donation_path(default_params.merge(id: donation.id))}']")
-          delete = page.at_css("a.btn-danger[href='#{donation_path(default_params.merge(id: donation.id))}']")
+          edit = page.at_css("a[href='#{edit_donation_path(donation.id)}']")
+          delete = page.at_css("a.btn-danger[href='#{donation_path(donation.id)}']")
           expect(edit.attr("class")).to match(/disabled/)
           expect(delete.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
@@ -139,7 +135,7 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
           donation = create(:donation, :with_items, item: item, organization: organization, storage_location: storage_location)
           create(:audit, :with_items, item: item, storage_location: storage_location, status: "finalized")
 
-          get edit_donation_path(organization.to_param, donation)
+          get edit_donation_path(donation)
 
           expect(response.body).to include("You’ve had an audit since this donation was started.")
           expect(response.body).to include("In the case that you are correcting a typo, rather than recording that the physical amounts being donated have changed,\n")
@@ -155,7 +151,7 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
         donation = create(:donation, :with_items, item: item, organization: organization, storage_location: storage_location)
         create(:audit, :with_items, item: item, storage_location: storage_location, status: "confirmed")
 
-        get edit_donation_path(organization.to_param, donation)
+        get edit_donation_path(donation)
 
         expect(response.body).to_not include("You’ve had an audit since this donation was started.")
         expect(response.body).to_not include("In the case that you are correcting a typo, rather than recording that the physical amounts being donated have changed,\n")
@@ -169,7 +165,7 @@ RSpec.describe "Donations", type: :request, skip_seed: true do
         storage_location = create(:storage_location, :with_items, item: item, organization: organization)
         donation = create(:donation, :with_items, item: item, organization: organization, storage_location: storage_location)
 
-        get edit_donation_path(organization.to_param, donation)
+        get edit_donation_path(donation)
 
         expect(response.body).to_not include("You’ve had an audit since this donation was started.")
         expect(response.body).to_not include("In the case that you are correcting a typo, rather than recording that the physical amounts being donated have changed,\n")

--- a/spec/requests/events_requests_spec.rb
+++ b/spec/requests/events_requests_spec.rb
@@ -3,9 +3,6 @@ require "rails_helper"
 RSpec.describe "Events", type: :request, skip_seed: true do
   let(:organization) { create(:organization) }
   let(:user) { create(:organization_admin, organization: organization) }
-  let(:default_params) do
-    {organization_name: organization.to_param}
-  end
   let(:storage_location) { create(:storage_location, organization: organization) }
   let(:storage_location2) { create(:storage_location, organization: organization) }
   let(:item) { create(:item, organization: organization, name: "Item1") }
@@ -15,7 +12,7 @@ RSpec.describe "Events", type: :request, skip_seed: true do
     before { sign_in(user) }
 
     describe "GET #index" do
-      let(:params) { default_params.merge(format: "html") }
+      let(:params) { {format: "html"} }
 
       subject do
         get events_path(params)
@@ -53,9 +50,7 @@ RSpec.describe "Events", type: :request, skip_seed: true do
       end
 
       context "with type filter" do
-        let(:params) do
-          default_params.merge(format: "html", filters: {by_type: "DonationEvent"})
-        end
+        let(:params) { {format: "html", filters: {by_type: "DonationEvent"}} }
 
         it "should not include the adjustment" do
           subject
@@ -70,9 +65,7 @@ RSpec.describe "Events", type: :request, skip_seed: true do
       end
 
       context "with item filter" do
-        let(:params) do
-          default_params.merge(format: "html", filters: {by_item: item.id})
-        end
+        let(:params) { {format: "html", filters: {by_item: item.id}} }
 
         it "should not include the other item" do
           subject
@@ -87,9 +80,7 @@ RSpec.describe "Events", type: :request, skip_seed: true do
       end
 
       context "with storage location filter" do
-        let(:params) do
-          default_params.merge(format: "html", filters: {by_storage_location: storage_location.id})
-        end
+        let(:params) { {format: "html", filters: {by_storage_location: storage_location.id}} }
 
         it "should not include the other storage location" do
           subject
@@ -105,10 +96,12 @@ RSpec.describe "Events", type: :request, skip_seed: true do
 
       context "with date filter" do
         let(:params) {
-          default_params.merge(format: "html",
+          {
+            format: "html",
             filters: {filters: {
               date_range: date_range_picker_params(3.days.ago, Time.zone.tomorrow)
-            }})
+            }}
+          }
         }
 
         it "should not include the old donation" do
@@ -127,9 +120,7 @@ RSpec.describe "Events", type: :request, skip_seed: true do
         let(:donation) do
           create(:donation, :with_items, item: item, organization: organization, item_quantity: 44)
         end
-        let(:params) do
-          default_params.merge(format: "html", eventable_id: donation.id, eventable_type: "Donation")
-        end
+        let(:params) { {format: "html", eventable_id: donation.id, eventable_type: "Donation"} }
         before do
           DonationEvent.publish(donation)
           donation.line_items.first.quantity = 33

--- a/spec/requests/item_categories_requests_spec.rb
+++ b/spec/requests/item_categories_requests_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) { {organization_name: organization.to_param} }
-
   before do
     sign_in(user)
   end
@@ -28,14 +26,14 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
     let!(:item_category) { create(:item_category, organization: organization) }
 
     it "renders a successful response" do
-      get item_category_url(default_params.merge(id: item_category.id))
+      get item_category_url(id: item_category.id)
       expect(response).to render_template(:show)
     end
   end
 
   describe "GET #new" do
     it "renders a successful response" do
-      get new_item_category_url(default_params)
+      get new_item_category_url
       expect(response).to render_template(:new)
     end
   end
@@ -44,7 +42,7 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
     let!(:item_category) { create(:item_category, organization: organization) }
 
     it "renders a successful response" do
-      get edit_item_category_url(default_params.merge(id: item_category.id))
+      get edit_item_category_url(id: item_category.id)
       expect(response).to render_template(:edit)
     end
   end
@@ -53,9 +51,9 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
     context "with valid parameters" do
       it "creates a new ItemCategory then redirects" do
         expect {
-          post item_categories_url(default_params.merge(item_category: valid_attributes))
+          post item_categories_url(item_category: valid_attributes)
         }.to change(ItemCategory, :count).by(1)
-        expect(response).to redirect_to(items_path(organization: organization))
+        expect(response).to redirect_to(items_path)
         expect(ItemCategory.last.organization).to eq(organization)
       end
     end
@@ -63,7 +61,7 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
     context "with invalid parameters" do
       it "does not create a new ItemCategory" do
         expect {
-          post item_categories_url(default_params.merge(item_category: invalid_attributes))
+          post item_categories_url(item_category: invalid_attributes)
         }.to change(ItemCategory, :count).by(0)
         expect(response).to render_template(:new)
       end
@@ -82,7 +80,7 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
       }
 
       it "updates the ItemCategory and redirects" do
-        put item_category_url(default_params.merge(id: item_category.id, item_category: new_attributes))
+        put item_category_url(id: item_category.id, item_category: new_attributes)
         item_category.reload
         expect(item_category.name).to eq("New Category")
         expect(item_category.description).to eq("New description")
@@ -92,7 +90,7 @@ RSpec.describe "ItemCategories", type: :request, skip_seed: true do
 
     context "with invalid parameters" do
       it "does not render a successful response" do
-        put item_category_url(default_params.merge(id: item_category.id, item_category: invalid_attributes))
+        put item_category_url(id: item_category.id, item_category: invalid_attributes)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/requests/items_requests_spec.rb
+++ b/spec/requests/items_requests_spec.rb
@@ -3,9 +3,6 @@ require "rails_helper"
 RSpec.describe "Items", type: :request, skip_seed: true do
   let(:organization) { create(:organization, short_name: "my_org") }
   let(:user) { create(:user, organization: organization) }
-  let(:default_params) do
-    { organization_name: "my_org" }
-  end
 
   describe "while signed in" do
     before do
@@ -14,7 +11,7 @@ RSpec.describe "Items", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get items_path(default_params.merge(format: response_format))
+        get items_path(format: response_format)
         response
       end
 
@@ -38,7 +35,7 @@ RSpec.describe "Items", type: :request, skip_seed: true do
     describe 'DELETE #deactivate' do
       let(:item) { create(:item, organization: organization, active: true) }
       let(:storage_location) { create(:storage_location, organization: organization) }
-      let(:params) { default_params.merge(id: item.id) }
+      let(:params) { {id: item.id} }
 
       it 'should be able to deactivate an item' do
         expect { delete deactivate_item_path(params) }.to change { item.reload.active }.from(true).to(false)
@@ -61,7 +58,7 @@ RSpec.describe "Items", type: :request, skip_seed: true do
     describe 'DELETE #destroy' do
       let!(:item) { create(:item, organization: organization, active: true) }
       let(:storage_location) { create(:storage_location, organization: organization) }
-      let(:params) { default_params.merge(id: item.id) }
+      let(:params) { {id: item.id} }
 
       it 'should be able to delete an item' do
         expect { delete item_path(params) }.to change { Item.count }.by(-1)
@@ -98,18 +95,18 @@ RSpec.describe "Items", type: :request, skip_seed: true do
       end
 
       it "should show all active items with corresponding buttons" do
-        get items_path(default_params)
+        get items_path
         page = Nokogiri::HTML(response.body)
         expect(response.body).to include("ACTIVEITEM")
         expect(response.body).to include("NODEACTIVATE")
         expect(response.body).to include("NODELETE")
         expect(response.body).not_to include("NOSIR")
-        button1 = page.css(".btn.btn-danger[href='/my_org/items/#{item.id}']")
+        button1 = page.css(".btn.btn-danger[href='/items/#{item.id}']")
         expect(button1.text.strip).to eq("Delete")
-        button2 = page.css(".btn[href='/my_org/items/#{non_delete_item.id}/deactivate']")
+        button2 = page.css(".btn[href='/items/#{non_delete_item.id}/deactivate']")
         expect(button2.text.strip).to eq("Deactivate")
         expect(button2.attr('class')).not_to match(/disabled/)
-        button3 = page.css(".btn[href='/my_org/items/#{non_deactivate_item.id}/deactivate']")
+        button3 = page.css(".btn[href='/items/#{non_deactivate_item.id}/deactivate']")
         expect(button3.text.strip).to eq("Deactivate")
         expect(button3.attr('class')).to match(/disabled/)
       end

--- a/spec/requests/kit_requests_spec.rb
+++ b/spec/requests/kit_requests_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
   let(:user) { create(:user, organization: organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
-  let(:default_params) do
-    {organization_name: organization.to_param}
-  end
   let!(:kit) { create(:kit, :with_item, organization: organization) }
 
   describe "while signed in" do
@@ -22,7 +19,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
       end
 
       it "should include deactivate" do
-        get kits_url(default_params)
+        get kits_url
         expect(response).to be_successful
         page = Nokogiri::HTML(response.body)
         expect(response.body).not_to include("DOOBIE")
@@ -39,7 +36,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
               kit.item.id => 10
             }
           })
-          get kits_url(default_params)
+          get kits_url
           expect(response).to be_successful
           page = Nokogiri::HTML(response.body)
           expect(page.css(".deactivate-kit-button.disabled")).not_to be_empty
@@ -50,7 +47,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
       context "when it is already deactivated" do
         it "should show reactivate button" do
           kit.deactivate
-          get kits_url(default_params.merge(include_inactive_items: true))
+          get kits_url(include_inactive_items: true)
           expect(response).to be_successful
           page = Nokogiri::HTML(response.body)
           expect(page.css(".deactivate-kit-button")).to be_empty
@@ -60,7 +57,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
 
       context "when show inactive is checked" do
         it "should show the inactive kit" do
-          get kits_url(default_params.merge(include_inactive_items: true))
+          get kits_url(include_inactive_items: true)
           expect(response).to be_successful
           expect(response.body).to include("DOOBIE")
         end
@@ -69,7 +66,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
 
     specify "PUT #deactivate" do
       expect(kit).to be_active
-      put deactivate_kit_url(kit, default_params)
+      put deactivate_kit_url(kit)
       expect(kit.reload).not_to be_active
       expect(response).to redirect_to(dashboard_path)
       expect(flash[:notice]).to eq("Kit has been deactivated!")
@@ -81,7 +78,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
         expect(kit).not_to be_active
         kit.line_items.first.item.update!(active: false)
 
-        put reactivate_kit_url(kit, default_params)
+        put reactivate_kit_url(kit)
         expect(kit.reload).not_to be_active
         expect(response).to redirect_to(dashboard_path)
         expect(flash[:alert]).to eq("Cannot reactivate kit - it has inactive items! Please reactivate the items first.")
@@ -90,7 +87,7 @@ RSpec.describe "/kits", type: :request, skip_seed: true do
       it "should successfully reactivate" do
         kit.deactivate
         expect(kit).not_to be_active
-        put reactivate_kit_url(kit, default_params)
+        put reactivate_kit_url(kit)
         expect(kit.reload).to be_active
         expect(response).to redirect_to(dashboard_path)
         expect(flash[:notice]).to eq("Kit has been reactivated!")

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -2,17 +2,13 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   before do
     sign_in(user)
   end
 
   describe "GET #index" do
     subject do
-      get partners_path(default_params.merge(format: response_format))
+      get partners_path(format: response_format)
       response
     end
 
@@ -38,7 +34,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
   end
 
   describe 'POST #create' do
-    subject { -> { post partners_path(default_params.merge(partner_attrs)) } }
+    subject { -> { post partners_path(partner_attrs) } }
 
     context 'when given valid partner attributes in the params' do
       let(:partner_attrs) do
@@ -57,7 +53,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
       it 'redirect to the partners index page' do
         subject.call
-        expect(response).to redirect_to(partners_path(default_params))
+        expect(response).to redirect_to(partners_path)
       end
     end
 
@@ -87,7 +83,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
   describe "GET #show" do
     subject do
-      get partner_path(partner, default_params.merge(format: response_format))
+      get partner_path(partner, format: response_format)
       response
     end
 
@@ -151,14 +147,14 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
   describe "GET #new" do
     it "returns http success" do
-      get new_partner_path(default_params)
+      get new_partner_path
       expect(response).to be_successful
     end
   end
 
   describe "GET #edit" do
     it "returns http success" do
-      get edit_partner_path(default_params.merge(id: create(:partner, organization: organization)))
+      get edit_partner_path(id: create(:partner, organization: organization))
       expect(response).to be_successful
     end
   end
@@ -168,7 +164,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
     context "with a csv file" do
       let(:file) { fixture_file_upload("#{model_class.name.underscore.pluralize}.csv", "text/csv") }
-      subject { post import_csv_partners_path(default_params), params: { file: file } }
+      subject { post import_csv_partners_path, params: { file: file } }
 
       it "invokes .import_csv" do
         expect(model_class).to respond_to(:import_csv).with(2).arguments
@@ -187,19 +183,19 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
     context "without a csv file" do
       it "redirects to :index" do
-        post import_csv_partners_path(default_params)
+        post import_csv_partners_path
         expect(response).to be_redirect
       end
 
       it "presents a flash error message" do
-        post import_csv_partners_path(default_params)
+        post import_csv_partners_path
         expect(response).to have_error "No file was attached!"
       end
     end
 
     context "csv file with wrong headers" do
       let(:file) { fixture_file_upload("wrong_headers.csv", "text/csv") }
-      subject { post import_csv_partners_path(default_params), params: { file: file } }
+      subject { post import_csv_partners_path, params: { file: file } }
 
       it "redirects to :index" do
         subject
@@ -218,12 +214,12 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       partner_params = { partner: { name: "A Partner", email: "partner@example.com", send_reminders: "false" } }
 
       it "creates a new partner" do
-        post partners_path(default_params.merge(partner_params))
+        post partners_path(partner_params)
         expect(response).to have_http_status(:found)
       end
 
       it "redirects to #index" do
-        post partners_path(default_params.merge(partner_params))
+        post partners_path(partner_params)
         expect(response).to redirect_to(partners_path)
       end
     end
@@ -232,7 +228,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       partner_params = { partner: { name: "", email: "" } }
 
       it "renders :new" do
-        post partners_path(default_params.merge(partner_params))
+        post partners_path(partner_params)
         expect(response).to render_template(:new)
       end
     end
@@ -244,13 +240,13 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
       it "update partner" do
         partner = create(:partner, organization: organization)
-        put partner_path(default_params.merge(id: partner, partner: partner_params))
+        put partner_path(id: partner, partner: partner_params)
         expect(response).to have_http_status(:found)
       end
 
       it "redirects to #show" do
         partner = create(:partner, organization: organization)
-        put partner_path(default_params.merge(id: partner, partner: partner_params))
+        put partner_path(id: partner, partner: partner_params)
         expect(response).to redirect_to(partner_path(partner))
       end
     end
@@ -260,7 +256,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
       it "renders :edit" do
         partner = create(:partner, organization: organization)
-        put partner_path(default_params.merge(id: partner, partner: partner_params))
+        put partner_path(id: partner, partner: partner_params)
         expect(response).to render_template(:edit)
       end
     end
@@ -268,7 +264,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
   describe "DELETE #destroy" do
     it "redirects to #index" do
-      delete partner_path(default_params.merge(id: create(:partner, organization: organization)))
+      delete partner_path(id: create(:partner, organization: organization))
       expect(response).to redirect_to(partners_path)
     end
   end
@@ -281,14 +277,14 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
     end
 
     it "sends the invite" do
-      post invite_partner_path(default_params.merge(id: partner.id))
+      post invite_partner_path(id: partner.id)
       expect(PartnerInviteService).to have_received(:new).with(partner: partner, force: true)
       expect(response).to have_http_status(:found)
     end
   end
 
   describe "POST #invite_partner_user" do
-    subject { -> { post invite_partner_user_partner_path(default_params.merge(id: partner.id, partner: partner.id, email: email, name: name)) } }
+    subject { -> { post invite_partner_user_partner_path(id: partner.id, partner: partner.id, email: email, name: name) } }
     let(:partner) { create(:partner, organization: organization) }
     let(:email) { Faker::Internet.email }
     let(:name) { Faker::Name.unique.name }
@@ -329,7 +325,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
 
     context "when the partner successfully deactivates" do
       it "changes the partner status to deactivated and redirects with flash" do
-        put deactivate_partner_path(default_params.merge(id: partner.id))
+        put deactivate_partner_path(id: partner.id)
 
         expect(partner.reload.status).to eq("deactivated")
         expect(response).to redirect_to(partners_path)
@@ -339,7 +335,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
   end
 
   describe "GET #approve_application" do
-    subject { -> { get approve_application_partner_path(default_params.merge(id: partner.id)) } }
+    subject { -> { get approve_application_partner_path(id: partner.id) } }
     let(:partner) { create(:partner, organization: organization) }
     let(:fake_partner_approval_service) { instance_double(PartnerApprovalService, call: -> {}) }
 
@@ -354,7 +350,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       end
 
       it 'should redirect to the partners index page with a success flash message' do
-        expect(response).to redirect_to(partners_path(organization_name: organization.to_param))
+        expect(response).to redirect_to(partners_path)
         expect(flash[:notice]).to eq("Partner approved!")
       end
     end
@@ -368,7 +364,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       end
 
       it 'should redirect to the partners index page with a failure flash message' do
-        expect(response).to redirect_to(partners_path(organization_name: organization.to_param))
+        expect(response).to redirect_to(partners_path)
         expect(flash[:error]).to eq("Failed to approve partner because: #{fake_error_msg}")
       end
     end
@@ -379,7 +375,7 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       let(:partner) { create(:partner, organization: organization, status: "deactivated") }
 
       it "changes the partner status to approved and redirects with flash" do
-        put reactivate_partner_path(default_params.merge(id: partner.id))
+        put reactivate_partner_path(id: partner.id)
 
         expect(partner.reload.status).to eq('approved')
         expect(response).to redirect_to(partners_path)
@@ -390,13 +386,13 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
     context "when trying to reactivate a partner who is not deactivated " do
       let(:partner) { create(:partner, organization: organization, status: "approved") }
       it "fails to change the partner status to reactivated and redirects with flash error message" do
-        put reactivate_partner_path(default_params.merge(id: partner.id))
+        put reactivate_partner_path(id: partner.id)
       end
     end
   end
 
   describe "POST #recertify_partner" do
-    subject { -> { post recertify_partner_partner_path(default_params.merge(id: partner.id)) } }
+    subject { -> { post recertify_partner_partner_path(id: partner.id) } }
     let(:partner) { create(:partner, organization: organization) }
     let(:fake_service) { instance_double(PartnerRequestRecertificationService, call: -> {}) }
 
@@ -442,13 +438,13 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       end
 
       it "sends invitation email and approve partner in single step" do
-        post invite_and_approve_partner_path(default_params.merge(id: partner.id))
+        post invite_and_approve_partner_path(id: partner.id)
 
         expect(PartnerInviteService).to have_received(:new).with(partner: partner, force: true)
         expect(response).to have_http_status(:found)
 
         expect(PartnerApprovalService).to have_received(:new).with(partner: partner)
-        expect(response).to redirect_to(partners_path(organization_name: organization.to_param))
+        expect(response).to redirect_to(partners_path)
         expect(flash[:notice]).to eq("Partner invited and approved!")
       end
     end
@@ -464,9 +460,9 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       end
 
       it "should redirect to the partners index page with a notice flash message" do
-        post invite_and_approve_partner_path(default_params.merge(id: partner.id))
+        post invite_and_approve_partner_path(id: partner.id)
 
-        expect(response).to redirect_to(partners_path(organization_name: organization.to_param))
+        expect(response).to redirect_to(partners_path)
         expect(flash[:notice]).to eq("Failed to invite #{partner.name}! #{fake_error_msg}")
       end
     end
@@ -482,9 +478,9 @@ RSpec.describe "Partners", type: :request, skip_seed: true do
       end
 
       it "should redirect to the partners index page with a notice flash message" do
-        post invite_and_approve_partner_path(default_params.merge(id: partner.id))
+        post invite_and_approve_partner_path(id: partner.id)
 
-        expect(response).to redirect_to(partners_path(organization_name: organization.to_param))
+        expect(response).to redirect_to(partners_path)
         expect(flash[:error]).to eq("Failed to approve partner because: #{fake_error_msg}")
       end
     end

--- a/spec/requests/product_drive_participants_requests_spec.rb
+++ b/spec/requests/product_drive_participants_requests_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(user)
@@ -15,7 +11,7 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get product_drive_participants_path(default_params.merge(format: response_format))
+        get product_drive_participants_path(format: response_format)
         response
       end
 
@@ -36,14 +32,14 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
 
     describe "GET #new" do
       it "returns http success" do
-        get new_product_drive_participant_path(default_params)
+        get new_product_drive_participant_path
         expect(response).to be_successful
       end
     end
 
     describe "GET #edit" do
       it "returns http success" do
-        get edit_product_drive_participant_path(default_params.merge(id: create(:product_drive_participant, organization: user.organization)))
+        get edit_product_drive_participant_path(id: create(:product_drive_participant, organization: user.organization))
         expect(response).to be_successful
       end
     end
@@ -53,7 +49,7 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
 
       context "with a csv file" do
         let(:file) { fixture_file_upload("#{model_class.name.underscore.pluralize}.csv", "text/csv") }
-        subject { post import_csv_product_drive_participants_path(default_params), params: { file: file } }
+        subject { post import_csv_product_drive_participants_path, params: { file: file } }
 
         it "invokes .import_csv" do
           expect(model_class).to respond_to(:import_csv).with(2).arguments
@@ -71,7 +67,7 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
       end
 
       context "without a csv file" do
-        subject { post import_csv_product_drive_participants_path(default_params) }
+        subject { post import_csv_product_drive_participants_path }
 
         it "redirects to :index" do
           subject
@@ -86,7 +82,7 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
 
       context "csv file with wrong headers" do
         let(:file) { fixture_file_upload("wrong_headers.csv", "text/csv") }
-        subject { post import_csv_product_drive_participants_path(default_params), params: { file: file } }
+        subject { post import_csv_product_drive_participants_path, params: { file: file } }
 
         it "redirects" do
           subject
@@ -102,19 +98,19 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
 
     describe "GET #show" do
       it "returns http success" do
-        get product_drive_participant_path(default_params.merge(id: create(:product_drive_participant, organization: organization)))
+        get product_drive_participant_path(id: create(:product_drive_participant, organization: organization))
         expect(response).to be_successful
       end
     end
 
     describe "XHR #create" do
       it "successful create" do
-        post product_drive_participants_path(default_params.merge(product_drive_participant: { name: "test", email: "123@mail.ru" }, xhr: true))
+        post product_drive_participants_path(product_drive_participant: { name: "test", email: "123@mail.ru" }, xhr: true)
         expect(response).to be_successful
       end
 
       it "flash error" do
-        post product_drive_participants_path(default_params.merge(product_drive_participant: { name: "test" }, xhr: true))
+        post product_drive_participants_path(product_drive_participant: { name: "test" }, xhr: true)
         expect(response).to be_successful
         expect(response).to have_error(/try again/i)
       end
@@ -122,14 +118,14 @@ RSpec.describe "ProductDriveParticipants", type: :request, skip_seed: true do
 
     describe "POST #create" do
       it "successful create" do
-        post product_drive_participants_path(default_params.merge(product_drive_participant:
-          { business_name: "businesstest", contact_name: "test", email: "123@mail.ru" }))
+        post product_drive_participants_path(product_drive_participant:
+          { business_name: "businesstest", contact_name: "test", email: "123@mail.ru" })
         expect(response).to redirect_to(product_drive_participants_path)
         expect(response).to have_notice(/added!/i)
       end
 
       it "flash error" do
-        post product_drive_participants_path(default_params.merge(product_drive_participant: { name: "test" }, xhr: true))
+        post product_drive_participants_path(product_drive_participant: { name: "test" }, xhr: true)
         expect(response).to be_successful
         expect(response).to have_error(/try again/i)
       end

--- a/spec/requests/product_drives_requests_spec.rb
+++ b/spec/requests/product_drives_requests_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.describe "ProductDrives", type: :request do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: organization) }
-  let(:default_params) { { organization_name: organization.to_param } }
 
   context "while not signed in" do
     it "is unsuccessful" do
-      get product_drives_path(default_params)
+      get product_drives_path
 
       expect(response).not_to be_successful
     end
@@ -19,6 +18,8 @@ RSpec.describe "ProductDrives", type: :request do
     end
 
     describe "GET #index" do
+      let(:default_params) { { } }
+
       subject { get product_drives_path(default_params) }
 
       it "returns http success" do
@@ -166,14 +167,14 @@ RSpec.describe "ProductDrives", type: :request do
 
     describe "GET #new" do
       it "returns http success" do
-        get new_product_drive_path(default_params)
+        get new_product_drive_path
         expect(response).to be_successful
       end
     end
 
     describe "POST#create" do
       it "returns redirect http status" do
-        post product_drives_path(default_params.merge(product_drive: attributes_for(:product_drive)))
+        post product_drives_path(product_drive: attributes_for(:product_drive))
         expect(response).to have_http_status(:redirect)
       end
     end
@@ -182,7 +183,7 @@ RSpec.describe "ProductDrives", type: :request do
       it "returns redirect http status" do
         product_drive = create(:product_drive, organization: organization)
 
-        put product_drive_path(default_params.merge(id: product_drive.id, product_drive: attributes_for(:product_drive)))
+        put product_drive_path(id: product_drive.id, product_drive: attributes_for(:product_drive))
         expect(response).to have_http_status(:redirect)
       end
     end
@@ -191,7 +192,7 @@ RSpec.describe "ProductDrives", type: :request do
       it "returns http success" do
         product_drive = create(:product_drive, organization: organization)
 
-        get edit_product_drive_path(default_params.merge(id: product_drive.id))
+        get edit_product_drive_path(id: product_drive.id)
         expect(response).to be_successful
       end
     end
@@ -200,7 +201,7 @@ RSpec.describe "ProductDrives", type: :request do
       it "returns http success" do
         product_drive = create(:product_drive, organization: organization)
 
-        get product_drive_path(default_params.merge(id: product_drive.id))
+        get product_drive_path(id: product_drive.id)
         expect(response).to be_successful
       end
 
@@ -209,7 +210,7 @@ RSpec.describe "ProductDrives", type: :request do
         participant = create(:product_drive_participant)
         create(:donation, :with_items, item_quantity: 4862167, source: Donation::SOURCES[:product_drive], product_drive: product_drive, product_drive_participant: participant)
 
-        get product_drive_path(default_params.merge(id: product_drive.id))
+        get product_drive_path(id: product_drive.id)
 
         expect(response.body).to include("4862167")
       end
@@ -219,7 +220,7 @@ RSpec.describe "ProductDrives", type: :request do
       it "redirects to the index" do
         product_drive = create(:product_drive, organization: organization)
 
-        delete product_drive_path(default_params.merge(id: product_drive.id))
+        delete product_drive_path(id: product_drive.id)
         expect(response).to redirect_to(product_drives_path)
       end
     end

--- a/spec/requests/profiles_requests_spec.rb
+++ b/spec/requests/profiles_requests_spec.rb
@@ -3,17 +3,13 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
   let(:user) { create(:user, organization: organization) }
   let(:partner) { create(:partner, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param, id: partner.id, partner_id: partner.id }
-  end
-
   before do
     sign_in(user)
   end
 
   describe "GET #edit" do
     it "returns http success" do
-      get edit_profile_path(default_params)
+      get edit_profile_path(id: partner.id, partner_id: partner.id)
       expect(response).to be_successful
     end
   end
@@ -26,7 +22,7 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
       end
 
       it "update partner" do
-        put profile_path(default_params.merge(id: partner, partner: partner_params))
+        put profile_path(id: partner, partner: partner_params)
         expect(response).to have_http_status(:redirect)
         expect(partner.reload.name).to eq("Awesome Partner")
         expect(partner.profile.reload.executive_director_email).to eq("awesomepartner@example.com")
@@ -43,7 +39,7 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
           }
         }
 
-        put profile_path(default_params.merge(id: partner, partner: new_partner_program_params))
+        put profile_path(id: partner, partner: new_partner_program_params)
 
         partner.profile.reload
 
@@ -56,7 +52,7 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
       end
 
       it "redirects to #show" do
-        put profile_path(default_params.merge(id: partner, partner: partner_params))
+        put profile_path(id: partner, partner: partner_params)
         expect(response).to redirect_to(partner_path(partner) + "#partner-information")
       end
     end
@@ -71,7 +67,7 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
       end
 
       it "update partner" do
-        put profile_path(default_params.merge(id: partner, partner: partner_params))
+        put profile_path(id: partner, partner: partner_params)
         expect(response).to have_http_status(:redirect)
         expect(partner.reload.name).to eq("Awesome Partner")
         expect(partner.profile.reload.executive_director_email).to eq("awesomepartner@example.com")
@@ -79,7 +75,7 @@ RSpec.describe "Profiles", type: :request, skip_seed: true do
       end
 
       it "should have blank values" do
-        put profile_path(default_params.merge(id: partner, partner: partner_params))
+        put profile_path(id: partner, partner: partner_params)
         expect(response).to have_http_status(:redirect)
         expect(partner.profile.website).to be_blank
       end

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
   let(:user) { create(:user, organization: organization) }
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   context "While signed in as a user >" do
     before do
       sign_in(user)
@@ -16,7 +12,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get purchases_path(default_params.merge(format: response_format))
+        get purchases_path(format: response_format)
         response
       end
 
@@ -37,7 +33,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
 
     describe "GET #new" do
       subject do
-        get new_purchase_path(default_params)
+        get new_purchase_path
         response
       end
 
@@ -59,7 +55,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
         end
 
         it "redirects to GET#edit" do
-          expect { post purchases_path(default_params.merge(purchase: purchase)) }
+          expect { post purchases_path(purchase: purchase) }
             .to change { Purchase.count }.by(1)
             .and change { PurchaseEvent.count }.by(1)
           expect(response).to redirect_to(purchases_path)
@@ -67,21 +63,21 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
 
         it "accepts :amount_spent_in_cents with dollar signs, commas, and periods" do
           formatted_purchase = purchase.merge(amount_spent: "$1,000.54")
-          post purchases_path(default_params.merge(purchase: formatted_purchase))
+          post purchases_path(purchase: formatted_purchase)
 
           expect(Purchase.last.amount_spent_in_cents).to eq 100_054
         end
 
         it "storage location defaults to organizations storage location" do
           purchase = create(:purchase)
-          get edit_purchase_path(organization.to_param, purchase)
+          get edit_purchase_path(purchase)
           expect(response.body).to match(/(<option selected="selected" value=")[0-9]*(">Smithsonian Conservation Center<\/option>)/)
         end
       end
 
       context "on failure" do
         it "renders GET#new with error" do
-          post purchases_path(default_params.merge(purchase: { storage_location_id: nil, amount_spent: nil }))
+          post purchases_path(purchase: { storage_location_id: nil, amount_spent: nil })
           expect(response).to be_successful # Will render :new
           expect(response.body).to include('Failed to create purchase due to')
         end
@@ -91,7 +87,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
     describe "PUT#update" do
       it "redirects to index after update" do
         purchase = create(:purchase, purchased_from: "Google")
-        put purchase_path(default_params.merge(id: purchase.id, purchase: { purchased_from: "Google" }))
+        put purchase_path(id: purchase.id, purchase: { purchased_from: "Google" })
         expect(response).to redirect_to(purchases_path)
       end
 
@@ -108,7 +104,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
         }
         purchase_params = { source: "Purchase Site", line_items_attributes: line_item_params }
         expect do
-          put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
+          put purchase_path(id: purchase.id, purchase: purchase_params)
         end.to change { purchase.storage_location.inventory_items.first.quantity }.by(5)
           .and change {
             View::Inventory.new(organization.id)
@@ -129,7 +125,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
           }
           purchase_params = { source: "Purchase Site", line_items_attributes: line_item_params }
           expect do
-            put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
+            put purchase_path(id: purchase.id, purchase: purchase_params)
           end.to change { purchase.storage_location.inventory_items.first.quantity }.by(-10)
             .and change {
                    View::Inventory.new(organization.id)
@@ -154,7 +150,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
           }
           purchase_params = { storage_location_id: new_storage_location.id, line_items_attributes: line_item_params }
           expect do
-            put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
+            put purchase_path(id: purchase.id, purchase: purchase_params)
           end.to change { original_storage_location.size }.by(-10) # removes the whole purchase of 10
           expect(new_storage_location.size).to eq 8
         end
@@ -182,7 +178,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
             }
           }
           purchase_params = { storage_location: new_storage_location, line_items_attributes: line_item_params }
-          put purchase_path(default_params.merge(id: purchase.id, purchase: purchase_params))
+          put purchase_path(id: purchase.id, purchase: purchase_params)
           expect(response).not_to redirect_to(anything)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
@@ -195,14 +191,14 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
       let(:storage_location) { create(:storage_location, organization: organization) }
 
       it "returns http success" do
-        get edit_purchase_path(default_params.merge(id: create(:purchase, organization: organization)))
+        get edit_purchase_path(id: create(:purchase, organization: organization))
         expect(response).to be_successful
       end
 
       it "storage location is correct" do
         storage2 = create(:storage_location, name: "storage2")
         purchase2 = create(:purchase, storage_location: storage2)
-        get edit_purchase_path(organization.to_param, purchase2)
+        get edit_purchase_path(purchase2)
         expect(response.body).to match(/(<option selected="selected" value=")[0-9]*(">storage2<\/option>)/)
       end
 
@@ -213,7 +209,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
           purchase = create(:purchase, :with_items, item: item, storage_location: storage_location)
           create(:audit, :with_items, item: item, storage_location: storage_location, status: "finalized")
 
-          get edit_purchase_path(organization.to_param, purchase)
+          get edit_purchase_path(purchase)
 
           expect(response.body).to include("You’ve had an audit since this purchase was started.")
           expect(response.body).to include("In the case that you are correcting a typo, rather than recording that the physical amounts being purchased have changed,")
@@ -228,7 +224,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
           purchase = create(:purchase, :with_items, item: item, storage_location: storage_location)
           create(:audit, :with_items, item: item, storage_location: storage_location, status: "confirmed")
 
-          get edit_purchase_path(organization.to_param, purchase)
+          get edit_purchase_path(purchase)
 
           expect(response.body).to_not include("You’ve had an audit since this purchase was started.")
           expect(response.body).to_not include("In the case that you are correcting a typo, rather than recording that the physical amounts being purchased have changed,")
@@ -242,7 +238,7 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
           storage_location = create(:storage_location, :with_items, item: item, organization: organization)
           purchase = create(:purchase, :with_items, item: item, storage_location: storage_location)
 
-          get edit_purchase_path(organization.to_param, purchase)
+          get edit_purchase_path(purchase)
 
           expect(response.body).to_not include("You’ve had an audit since this purchase was started.")
           expect(response.body).to_not include("In the case that you are correcting a typo, rather than recording that the physical amounts being purchased have changed,")
@@ -256,10 +252,10 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
       let!(:purchase) { create(:purchase, :with_items, item: item) }
 
       it "shows an enabled edit button" do
-        get purchase_path(default_params.merge(id: purchase.id))
+        get purchase_path(id: purchase.id)
         expect(response).to be_successful
         page = Nokogiri::HTML(response.body)
-        edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
+        edit = page.at_css("a[href='#{edit_purchase_path(id: purchase.id)}']")
         expect(edit.attr("class")).not_to match(/disabled/)
         expect(response.body).not_to match(/please make the following items active:/)
       end
@@ -270,9 +266,9 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
         end
 
         it "shows a disabled edit button" do
-          get purchase_path(default_params.merge(id: purchase.id))
+          get purchase_path(id: purchase.id)
           page = Nokogiri::HTML(response.body)
-          edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
+          edit = page.at_css("a[href='#{edit_purchase_path(id: purchase.id)}']")
           expect(edit.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
         end
@@ -285,10 +281,10 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
         end
 
         it "shows a disabled edit and delete buttons" do
-          get purchase_path(default_params.merge(id: purchase.id))
+          get purchase_path(purchase.id)
           page = Nokogiri::HTML(response.body)
-          edit = page.at_css("a[href='#{edit_purchase_path(default_params.merge(id: purchase.id))}']")
-          delete = page.at_css("a.btn-danger[href='#{purchase_path(default_params.merge(id: purchase.id))}']")
+          edit = page.at_css("a[href='#{edit_purchase_path(purchase.id)}']")
+          delete = page.at_css("a.btn-danger[href='#{purchase_path(purchase.id)}']")
           expect(edit.attr("class")).to match(/disabled/)
           expect(delete.attr("class")).to match(/disabled/)
           expect(response.body).to match(/please make the following items active: #{item.name}/)
@@ -299,13 +295,13 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
     describe "DELETE #destroy" do
       # normal users are not authorized
       it "redirects to the dashboard" do
-        delete purchase_path(default_params.merge(id: create(:purchase, organization: organization)))
+        delete purchase_path(id: create(:purchase, organization: organization))
         expect(response).to redirect_to(dashboard_path)
       end
 
       it "does not delete a purchase" do
         purchase = create(:purchase, purchased_from: "Google")
-        expect { delete purchase_path(default_params.merge(id: purchase.id)) }.to_not change(Purchase, :count)
+        expect { delete purchase_path(id: purchase.id) }.to_not change(Purchase, :count)
       end
     end
   end
@@ -317,24 +313,24 @@ RSpec.describe "Purchases", type: :request, skip_seed: true do
 
     describe "DELETE #destroy" do
       it "redirects to the index" do
-        delete purchase_path(default_params.merge(id: create(:purchase, organization: organization)))
+        delete purchase_path(id: create(:purchase, organization: organization))
         expect(response).to redirect_to(purchases_path)
       end
 
       it "decreases storage location inventory" do
         purchase = create(:purchase, :with_items, item_quantity: 10)
         storage_location = purchase.storage_location
-        expect { delete purchase_path(default_params.merge(id: purchase.id)) }.to change { storage_location.size }.by(-10)
+        expect { delete purchase_path(id: purchase.id) }.to change { storage_location.size }.by(-10)
       end
 
       it "deletes a purchase" do
         purchase = create(:purchase, purchased_from: "Google")
-        expect { delete purchase_path(default_params.merge(id: purchase.id)) }.to change(Purchase, :count).by(-1)
+        expect { delete purchase_path(id: purchase.id) }.to change(Purchase, :count).by(-1)
       end
 
       it "displays the proper flash notice" do
         purchase_id = create(:purchase, purchased_from: "Google").id.to_s
-        delete purchase_path(default_params.merge(id: purchase_id))
+        delete purchase_path(id: purchase_id)
         expect(response).to have_notice "Purchase #{purchase_id} has been removed!"
       end
     end

--- a/spec/requests/reports/annual_reports_requests_spec.rb
+++ b/spec/requests/reports/annual_reports_requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Annual Reports", type: :request, skip_seed: true do
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
   let(:default_params) do
-    { organization_name: organization.to_param, year: 2018 }
+    { year: 2018 }
   end
 
   context "While signed in" do
@@ -53,7 +53,7 @@ RSpec.describe "Annual Reports", type: :request, skip_seed: true do
       end
 
       it "returns not found if the year params is not number" do
-        get reports_annual_report_path({ organization_name: organization.to_param, year: 'invalid' })
+        get reports_annual_report_path({ year: 'invalid' })
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/spec/requests/requests_requests_spec.rb
+++ b/spec/requests/requests_requests_spec.rb
@@ -4,16 +4,12 @@ RSpec.describe 'Requests', type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   context 'When signed' do
     before { sign_in(user) }
 
     describe "GET #index" do
       subject do
-        get requests_path(default_params.merge(format: response_format))
+        get requests_path(format: response_format)
         response
       end
 
@@ -39,7 +35,7 @@ RSpec.describe 'Requests', type: :request, skip_seed: true do
         let(:request) { create(:request, organization: organization) }
 
         it 'responds with success' do
-          get request_path(request, default_params)
+          get request_path(request)
 
           expect(response).to have_http_status(:ok)
         end
@@ -47,7 +43,7 @@ RSpec.describe 'Requests', type: :request, skip_seed: true do
 
       context 'When the request does not exist' do
         it 'responds with not found' do
-          get request_path(1, default_params)
+          get request_path(id: 1)
 
           expect(response).to have_http_status(:not_found)
         end
@@ -60,13 +56,13 @@ RSpec.describe 'Requests', type: :request, skip_seed: true do
 
         it 'changes the request status from pending to started' do
           expect do
-            post start_request_path(request, default_params)
+            post start_request_path(request)
             request.reload
           end.to change(request, :status).from('pending').to('started')
         end
 
         it 'redirects to new_distribution_path and flashes a notice', :aggregate_failures do
-          post start_request_path(request, default_params)
+          post start_request_path(request)
 
           expect(flash[:notice]).to eq('Request started')
           expect(response).to redirect_to(new_distribution_path(request_id: request.id))
@@ -75,7 +71,7 @@ RSpec.describe 'Requests', type: :request, skip_seed: true do
 
       context 'When the request does not exist' do
         it 'responds with not found' do
-          post start_request_path(organization.id, 1)
+          post start_request_path(1)
 
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Sessions", type: :request, order: :defined, skip_seed: true do
 
     it "properly accesses the organization dashboard" do
       get root_path
-      expect(response).to redirect_to(dashboard_url(organization))
+      expect(response).to redirect_to(dashboard_url)
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe "Sessions", type: :request, order: :defined, skip_seed: true do
             post user_session_path, params: {user: {email: partner_user.email, password: "password!"}}
             get root_path
 
-            expect(response).to redirect_to(dashboard_url(organization))
+            expect(response).to redirect_to(dashboard_url)
           end
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe "Sessions", type: :request, order: :defined, skip_seed: true do
       it "signs in as org_admin role" do
         post user_session_path, params: {user: {email: partner_user.email, password: "password!"}}
         get root_path
-        expect(response).to redirect_to(dashboard_url(organization))
+        expect(response).to redirect_to(dashboard_url)
       end
     end
   end

--- a/spec/requests/static_requests_spec.rb
+++ b/spec/requests/static_requests_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Static", type: :request do
     describe "GET #index" do
       it "redirects to organization dashboard" do
         get root_path
-        expect(response).to redirect_to(dashboard_url(@organization))
+        expect(response).to redirect_to(dashboard_url)
       end
     end
   end

--- a/spec/requests/storage_locations_requests_spec.rb
+++ b/spec/requests/storage_locations_requests_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe "StorageLocations", type: :request do
-  let(:default_params) do
-    { organization_name: @organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(@user)
@@ -15,7 +11,7 @@ RSpec.describe "StorageLocations", type: :request do
         let(:response_format) { 'html' }
 
         it "succeeds" do
-          get storage_locations_path(default_params.merge(format: response_format))
+          get storage_locations_path(format: response_format)
           expect(response).to be_successful
         end
 
@@ -23,13 +19,13 @@ RSpec.describe "StorageLocations", type: :request do
           let!(:discarded_storage_location) { create(:storage_location, name: "Some Random Location", discarded_at: rand(10.years).seconds.ago) }
 
           it "does not includes the inactive location" do
-            get storage_locations_path(default_params.merge(format: response_format))
+            get storage_locations_path(format: response_format)
             expect(response.parsed_body).to_not include(discarded_storage_location.name)
           end
 
           context "with include_inactive_locations" do
             it "includes the inactive location" do
-              get storage_locations_path(default_params.merge(include_inactive_storage_locations: "1", format: response_format))
+              get storage_locations_path(include_inactive_storage_locations: "1", format: response_format)
               expect(response.parsed_body).to include(discarded_storage_location.name)
             end
           end
@@ -39,7 +35,7 @@ RSpec.describe "StorageLocations", type: :request do
       context "csv" do
         let(:response_format) { 'csv' }
         it "succeeds" do
-          get storage_locations_path(default_params.merge(format: response_format))
+          get storage_locations_path(format: response_format)
           expect(response).to be_successful
         end
 
@@ -61,7 +57,7 @@ RSpec.describe "StorageLocations", type: :request do
               item3.id => 1
             }
           })
-          get storage_locations_path(default_params.merge(format: response_format))
+          get storage_locations_path(format: response_format)
 
           expect(response.body.split("\n")[0]).to eq([StorageLocation.csv_export_headers, item3.name, item2.name, item1.name].join(','))
         end
@@ -97,7 +93,7 @@ RSpec.describe "StorageLocations", type: :request do
           end
 
           it "Generates csv with Storage Location fields, alphabetized item names, item quantities lined up in their columns, and zeroes for no inventory" do
-            get storage_locations_path(default_params.merge(format: response_format))
+            get storage_locations_path(format: response_format)
             # The first address below is quoted since it contains commas
             csv = <<~CSV
               Name,Address,Square Footage,Warehouse Type,Total Inventory,A,B,C,D
@@ -114,14 +110,14 @@ RSpec.describe "StorageLocations", type: :request do
 
     describe "GET #new" do
       it "returns http success" do
-        get new_storage_location_path(default_params)
+        get new_storage_location_path
         expect(response).to be_successful
       end
     end
 
     describe "GET #edit" do
       it "returns http success" do
-        get edit_storage_location_path(default_params.merge(id: create(:storage_location, organization: @organization)))
+        get edit_storage_location_path(id: create(:storage_location, organization: @organization))
         expect(response).to be_successful
       end
     end
@@ -131,7 +127,7 @@ RSpec.describe "StorageLocations", type: :request do
 
       context "with a csv file" do
         let(:file) { fixture_file_upload("#{model_class.name.underscore.pluralize}.csv", "text/csv") }
-        subject { post import_csv_storage_locations_path(default_params), params: { file: file } }
+        subject { post import_csv_storage_locations_path, params: { file: file } }
 
         it "invokes .import_csv" do
           expect(model_class).to respond_to(:import_csv).with(2).arguments
@@ -149,7 +145,7 @@ RSpec.describe "StorageLocations", type: :request do
       end
 
       context "without a csv file" do
-        subject { post import_csv_storage_locations_path(default_params) }
+        subject { post import_csv_storage_locations_path }
 
         it "redirects to :index" do
           subject
@@ -164,7 +160,7 @@ RSpec.describe "StorageLocations", type: :request do
 
       context "csv file with wrong headers" do
         let(:file) { fixture_file_upload("wrong_headers.csv", "text/csv") }
-        subject { post import_csv_storage_locations_path(default_params), params: { file: file } }
+        subject { post import_csv_storage_locations_path, params: { file: file } }
 
         it "redirects" do
           subject
@@ -222,7 +218,7 @@ RSpec.describe "StorageLocations", type: :request do
         let(:response_format) { 'html' }
 
         it "should return a correct response" do
-          get storage_location_path(storage_location, default_params.merge(format: response_format))
+          get storage_location_path(storage_location, format: response_format)
           expect(response).to be_successful
           expect(response.body).to include("Smithsonian")
           expect(response.body).to include("Test Item")
@@ -243,8 +239,8 @@ RSpec.describe "StorageLocations", type: :request do
                 inventory_item.update!(quantity: 300)
               end
               travel 2.weeks do
-                get storage_location_path(storage_location, default_params.merge(format: response_format,
-                  version_date: 9.days.ago.to_date.to_fs(:db)))
+                get storage_location_path(storage_location, format: response_format,
+                  version_date: 9.days.ago.to_date.to_fs(:db))
                 expect(response).to be_successful
                 expect(response.body).to include("Smithsonian")
                 expect(response.body).to include("Test Item")
@@ -255,8 +251,8 @@ RSpec.describe "StorageLocations", type: :request do
 
           context "with no version found" do
             it "should show N/A" do
-              get storage_location_path(storage_location, default_params.merge(format: response_format,
-                version_date: 1.week.ago.to_date.to_fs(:db)))
+              get storage_location_path(storage_location, format: response_format,
+                version_date: 1.week.ago.to_date.to_fs(:db))
               expect(response).to be_successful
               expect(response.body).to include("Smithsonian")
               expect(response.body).to include("Test Item")
@@ -271,7 +267,7 @@ RSpec.describe "StorageLocations", type: :request do
         let(:response_format) { 'csv' }
 
         it "should be successful" do
-          get storage_location_path(storage_location, default_params.merge(format: response_format))
+          get storage_location_path(storage_location, format: response_format)
           expect(response).to be_successful
         end
       end
@@ -279,7 +275,7 @@ RSpec.describe "StorageLocations", type: :request do
 
     describe "GET #destroy" do
       it "redirects to #index" do
-        delete storage_location_path(default_params.merge(id: create(:storage_location, organization: @organization)))
+        delete storage_location_path(id: create(:storage_location, organization: @organization))
         expect(response).to redirect_to(storage_locations_path)
       end
     end
@@ -289,7 +285,7 @@ RSpec.describe "StorageLocations", type: :request do
         let(:storage_location) { create(:storage_location, :with_items, organization: @organization) }
 
         it "does not discard" do
-          put storage_location_deactivate_path(default_params.merge(storage_location_id: storage_location.id, format: :json))
+          put storage_location_deactivate_path(storage_location_id: storage_location.id, format: :json)
           expect(storage_location.reload.discarded?).to eq(false)
         end
       end
@@ -297,7 +293,7 @@ RSpec.describe "StorageLocations", type: :request do
       let(:storage_location) { create(:storage_location, organization: @organization) }
 
       it "discards" do
-        put storage_location_deactivate_path(default_params.merge(storage_location_id: storage_location.id, format: :json))
+        put storage_location_deactivate_path(storage_location_id: storage_location.id, format: :json)
         expect(storage_location.reload.discarded?).to eq(true)
       end
     end
@@ -306,7 +302,7 @@ RSpec.describe "StorageLocations", type: :request do
       let(:storage_location) { create(:storage_location, organization: @organization, discarded_at: Time.zone.now) }
 
       it "undiscards" do
-        put storage_location_reactivate_path(default_params.merge(storage_location_id: storage_location.id, format: :json))
+        put storage_location_reactivate_path(storage_location_id: storage_location.id, format: :json)
         expect(storage_location.reload.discarded?).to eq(false)
       end
     end
@@ -334,7 +330,7 @@ RSpec.describe "StorageLocations", type: :request do
 
       context "without any overrides" do
         it "returns a collection that only includes items at the storage location" do
-          get inventory_storage_location_path(storage_location, default_params.merge(format: :json))
+          get inventory_storage_location_path(storage_location, format: :json)
           expect(response.parsed_body).to eq(items_at_storage_location)
           expect(response.parsed_body).to eq(inventory_items_at_storage_location)
         end
@@ -343,7 +339,7 @@ RSpec.describe "StorageLocations", type: :request do
       context "when also including inactive items" do
         it "returns a collection that also includes items that have been deactivated" do
           @organization.items.first.update(active: false)
-          get inventory_storage_location_path(storage_location, default_params.merge(format: :json, include_deactivated_items: true))
+          get inventory_storage_location_path(storage_location, format: :json, include_deactivated_items: true)
           @organization.items.first.update(active: true)
           expect(response.parsed_body).to eq(items_at_storage_location + inactive_items)
           expect(response.parsed_body).to eq(inventory_items_at_storage_location + inactive_inventory_items)
@@ -352,12 +348,12 @@ RSpec.describe "StorageLocations", type: :request do
 
       context "when also including omitted items" do
         it "returns a collection that also includes all items, but with zeroed quantities" do
-          get inventory_storage_location_path(storage_location, default_params.merge(format: :json, include_omitted_items: true))
+          get inventory_storage_location_path(storage_location, format: :json, include_omitted_items: true)
           expect(response.parsed_body.count).to eq(@organization.items.count)
         end
 
         it "contains a collection of ducktyped entries that respond the same" do
-          get inventory_storage_location_path(storage_location, default_params.merge(format: :json, include_omitted_items: true))
+          get inventory_storage_location_path(storage_location, format: :json, include_omitted_items: true)
           collection = response.parsed_body
           expect(collection.first.keys).to match_array(%w[item_id item_name quantity])
           expect(collection.last.keys).to match_array(%w[item_id item_name quantity])

--- a/spec/requests/transfers_requests_spec.rb
+++ b/spec/requests/transfers_requests_spec.rb
@@ -2,10 +2,6 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:valid_params) do
-    { organization_name: organization.short_name }
-  end
-
   context "While signed in" do
     before do
       sign_in(user)
@@ -13,7 +9,7 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get transfers_path(valid_params.merge(format: response_format))
+        get transfers_path(format: response_format)
         response
       end
 
@@ -36,14 +32,14 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
             it 'only returns the correct obejects' do
               start_date = 3.days.ago.to_formatted_s(:date_picker)
               end_date = Time.zone.today.to_formatted_s(:date_picker)
-              get transfers_path(valid_params.merge(filters: { date_range: "#{start_date} - #{end_date}" }))
+              get transfers_path(filters: { date_range: "#{start_date} - #{end_date}" })
               expect(assigns(:transfers)).to eq([new_transfer])
             end
           end
 
           context 'when date parameters are not supplied' do
             it 'returns all objects' do
-              get transfers_path(valid_params)
+              get transfers_path
               expect(assigns(:transfers)).to eq([old_transfer, new_transfer])
             end
           end
@@ -66,14 +62,14 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
           from_id: create(:storage_location, organization: organization).id
         )
 
-        expect { post transfers_path(valid_params.merge(transfer: attributes)) }
+        expect { post transfers_path(transfer: attributes) }
           .to change { Transfer.count }.by(1)
           .and change { TransferEvent.count }.by(1)
         expect(response).to redirect_to(transfers_path)
       end
 
       it "renders to #new when failing" do
-        post transfers_path(valid_params.merge(transfer: { from_id: nil, to_id: nil }))
+        post transfers_path(transfer: { from_id: nil, to_id: nil })
         expect(response).to be_successful # Will render :new
         expect(response).to render_template("new")
         expect(flash.keys).to match_array(['error'])
@@ -81,7 +77,7 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
     end
 
     describe "GET #new" do
-      subject { get new_transfer_path(valid_params) }
+      subject { get new_transfer_path }
       it "returns http success" do
         subject
         expect(response).to be_successful
@@ -89,7 +85,7 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
     end
 
     describe "GET #show" do
-      subject { get transfer_path(valid_params.merge(id: create(:transfer, organization: organization))) }
+      subject { get transfer_path(id: create(:transfer, organization: organization)) }
       it "returns http success" do
         subject
         expect(response).to be_successful
@@ -99,7 +95,7 @@ RSpec.describe "Transfers", type: :request, skip_seed: true do
     describe 'DELETE #destroy' do
       let(:transfer_id) { create(:transfer, organization: organization).id.to_s }
       let(:fake_destroy_service) { instance_double(TransferDestroyService) }
-      subject { delete transfer_path(valid_params.merge(id: transfer_id)) }
+      subject { delete transfer_path(id: transfer_id) }
       before do
         allow(TransferDestroyService).to receive(:new).with(transfer_id: transfer_id).and_return(fake_destroy_service)
       end

--- a/spec/requests/users/omniauth_callbacks_requests_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_requests_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Users - Omniauth Callbacks", type: :request do
         post "/users/auth/google_oauth2/callback"
         expect(session["google.token"]).to eq("token")
         expect(session["google.refresh_token"]).to eq("refresh token")
-        expect(response).to redirect_to("/?organization_name=#{@user.organization.short_name}")
+        expect(response).to redirect_to(root_path)
       end
     end
 

--- a/spec/requests/users_requests_spec.rb
+++ b/spec/requests/users_requests_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe "Users", type: :request, skip_seed: true do
   let(:organization_admin) { create(:organization_admin, organization: organization) }
 
   let(:partner) { create(:partner) }
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
 
   before do
     sign_in(user)
@@ -16,14 +13,14 @@ RSpec.describe "Users", type: :request, skip_seed: true do
 
   describe "GET #index" do
     it "returns http success" do
-      get users_path(default_params)
+      get users_path
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns http success" do
-      get new_user_path(default_params)
+      get new_user_path
       expect(response).to be_successful
     end
   end
@@ -31,11 +28,11 @@ RSpec.describe "Users", type: :request, skip_seed: true do
   describe "POST #send_partner_user_reset_password" do
     let(:partner) { create(:partner, organization: organization) }
     let!(:user) { create(:partner_user, partner: partner, email: "me@partner.com") }
-    let(:params) { default_params.merge(partner_id: partner.id, email: "me@partner.com") }
+    let(:params) { { organization_name: organization.short_name, partner_id: partner.id, email: "me@partner.com" } }
 
     it "should send a password" do
       post partner_user_reset_password_users_path(params)
-      expect(response).to redirect_to(root_path(organization_name: organization.to_param))
+      expect(response).to redirect_to(root_path)
       expect(ActionMailer::Base.deliveries.size).to eq(1)
     end
 
@@ -64,14 +61,13 @@ RSpec.describe "Users", type: :request, skip_seed: true do
       org = create(:organization)
       create(:user, organization: org, name: "ADMIN USER")
     end
+
     context "with a partner role" do
       it "should redirect to the partner path" do
         user.add_role(Role::PARTNER, partner)
         get switch_to_role_users_path(organization,
           role_id: user.roles.find { |r| r.name == Role::PARTNER.to_s })
-        # all bank controllers add organization_id to all routes - there's no way to
-        # avoid it
-        expect(response).to redirect_to(partners_dashboard_path(organization_name: organization.to_param))
+        expect(response).to redirect_to(partners_dashboard_path)
       end
 
       it "should set last_role to partner" do

--- a/spec/requests/vendors_requests_spec.rb
+++ b/spec/requests/vendors_requests_spec.rb
@@ -2,10 +2,6 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
   let(:organization) { create(:organization, skip_items: true) }
   let(:user) { create(:user, organization: organization) }
 
-  let(:default_params) do
-    { organization_name: organization.to_param }
-  end
-
   context "While signed in" do
     before do
       sign_in(user)
@@ -13,7 +9,7 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
     describe "GET #index" do
       subject do
-        get vendors_path(default_params.merge(format: response_format))
+        get vendors_path(format: response_format)
         response
       end
 
@@ -34,14 +30,14 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
     describe "GET #new" do
       it "returns http success" do
-        get new_vendor_path(default_params)
+        get new_vendor_path
         expect(response).to be_successful
       end
     end
 
     describe "GET #edit" do
       it "returns http success" do
-        get edit_vendor_path(default_params.merge(id: create(:vendor, organization: user.organization)))
+        get edit_vendor_path(id: create(:vendor, organization: user.organization))
         expect(response).to be_successful
       end
     end
@@ -51,7 +47,7 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
       context "with a csv file" do
         let(:file) { fixture_file_upload("#{model_class.name.underscore.pluralize}.csv", "text/csv") }
-        subject { post import_csv_vendors_path(default_params), params: { file: file } }
+        subject { post import_csv_vendors_path, params: { file: file } }
 
         it "invokes .import_csv" do
           expect(model_class).to respond_to(:import_csv).with(2).arguments
@@ -69,7 +65,7 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
       end
 
       context "without a csv file" do
-        subject { post import_csv_vendors_path(default_params) }
+        subject { post import_csv_vendors_path }
 
         it "redirects to :index" do
           subject
@@ -84,7 +80,7 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
       context "csv file with wrong headers" do
         let(:file) { fixture_file_upload("wrong_headers.csv", "text/csv") }
-        subject { post import_csv_vendors_path(default_params), params: { file: file } }
+        subject { post import_csv_vendors_path, params: { file: file } }
 
         it "redirects" do
           subject
@@ -100,13 +96,13 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
     describe "GET #show" do
       it "returns http success" do
-        get vendor_path(default_params.merge(id: create(:vendor, organization: organization)))
+        get vendor_path(id: create(:vendor, organization: organization))
         expect(response).to be_successful
       end
     end
 
     describe "DELETE #destroy" do
-      subject { delete vendor_path(default_params.merge(id: create(:vendor))) }
+      subject { delete vendor_path(id: create(:vendor)) }
       it "does not have a route for this" do
         expect { subject }.to raise_error(ActionController::RoutingError)
       end
@@ -114,12 +110,12 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
     describe "XHR #create" do
       it "successful create" do
-        post vendors_path(default_params.merge(vendor: { name: "test", email: "123@mail.ru" }))
+        post vendors_path(vendor: { name: "test", email: "123@mail.ru" })
         expect(response).to be_successful
       end
 
       it "flash error" do
-        post vendors_path(default_params.merge(vendor: { name: "test" }))
+        post vendors_path(vendor: { name: "test" })
         expect(response).to be_successful
         expect(response).to have_error(/try again/i)
       end
@@ -127,13 +123,13 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
     describe "POST #create" do
       it "successful create" do
-        post vendors_path(default_params.merge(vendor: { business_name: "businesstest", contact_name: "test", email: "123@mail.ru" }))
+        post vendors_path(vendor: { business_name: "businesstest", contact_name: "test", email: "123@mail.ru" })
         expect(response).to redirect_to(vendors_path)
         expect(response).to have_notice(/added!/i)
       end
 
       it "flash error" do
-        post vendors_path(default_params.merge(vendor: { name: "test" }, xhr: true))
+        post vendors_path(vendor: { name: "test" }, xhr: true)
         expect(response).to be_successful
         expect(response).to have_error(/try again/i)
       end
@@ -146,7 +142,7 @@ RSpec.describe "Vendors", type: :request, skip_seed: true do
 
     describe "when on vendors index page" do
       it "has the correct import type" do
-        get vendors_path(default_params.merge(format: 'html'))
+        get vendors_path(format: 'html')
 
         expect(response.body).to include('Import Vendors')
       end

--- a/spec/support/csv_import_shared_example.rb
+++ b/spec/support/csv_import_shared_example.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples "csv import" do
   context "with a csv file" do
     let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/files/#{model_class.name.underscore.pluralize}.csv", "text/csv" }
-    subject { post :import_csv, params: default_params.merge(file: file) }
+    subject { post :import_csv, params: {file: file} }
 
     it "invokes .import_csv" do
       expect(model_class).to respond_to(:import_csv).with(2).arguments
@@ -17,7 +17,7 @@ RSpec.shared_examples "csv import" do
   end
 
   context "without a csv file" do
-    subject { post :import_csv, params: default_params }
+    subject { post :import_csv }
 
     it "redirects to :index" do
       expect(subject).to be_redirect
@@ -30,7 +30,7 @@ RSpec.shared_examples "csv import" do
 
   context "csv file with wrong headers" do
     let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/files/wrong_headers.csv", "text/csv" }
-    subject { post :import_csv, params: default_params.merge(file: file) }
+    subject { post :import_csv, params: {file: file} }
 
     it "redirects to :index" do
       expect(subject).to be_redirect

--- a/spec/support/pages/organization_new_distribution_page.rb
+++ b/spec/support/pages/organization_new_distribution_page.rb
@@ -1,6 +1,0 @@
-class OrganizationNewDistributionPage < OrganizationPage
-  def org_page_path
-    # relative path within organization's subtree
-    "distributions/new"
-  end
-end

--- a/spec/support/pages/organization_new_donation_page.rb
+++ b/spec/support/pages/organization_new_donation_page.rb
@@ -1,8 +1,0 @@
-require_relative "organization_page"
-
-class OrganizationNewDonationPage < OrganizationPage
-  def org_page_path
-    # relative path within organization's subtree
-    "donations/new"
-  end
-end

--- a/spec/support/pages/organization_new_purchase_page.rb
+++ b/spec/support/pages/organization_new_purchase_page.rb
@@ -1,8 +1,0 @@
-require_relative "organization_page"
-
-class OrganizationNewPurchasePage < OrganizationPage
-  def org_page_path
-    # relative path within organization's subtree
-    "purchases/new"
-  end
-end

--- a/spec/support/pages/organization_page.rb
+++ b/spec/support/pages/organization_page.rb
@@ -1,15 +1,9 @@
 require_relative "system_spec_page"
 
 class OrganizationPage < SystemSpecPage
-  attr_reader :org_short_name
-
-  def initialize(org_short_name:)
-    @org_short_name = org_short_name
-  end
-
   def path
     # Implement org_page_path on subclasses
-    "/" + org_short_name + "/" + org_page_path
+    "/" + org_page_path
   end
 
   def org_page_path

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe "Adjustment management", type: :system, js: true do
-  let!(:url_prefix) { "/#{@organization.to_param}" }
   let!(:storage_location) { create(:storage_location, :with_items, organization: @organization) }
   let(:add_quantity) { 10 }
   let(:sub_quantity) { -10 }
 
-  subject { url_prefix + "/adjustments" }
+  subject { adjustments_path }
 
   before do
     sign_in(@user)
@@ -62,7 +61,7 @@ RSpec.describe "Adjustment management", type: :system, js: true do
       it "politely informs the user that they're adjusting way too hard", js: true do
         sub_quantity = -9001
         storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: @organization)
-        visit url_prefix + "/adjustments"
+        visit adjustments_path
         click_on "New Adjustment"
         select storage_location.name, from: "From storage location"
         fill_in "Comment", with: "something"
@@ -79,7 +78,7 @@ RSpec.describe "Adjustment management", type: :system, js: true do
         sub_quantity = -9
 
         storage_location = create(:storage_location, :with_items, name: "PICK THIS ONE", item_quantity: 10, organization: @organization)
-        visit url_prefix + "/adjustments"
+        visit adjustments_path
         click_on "New Adjustment"
         select storage_location.name, from: "From storage location"
         fill_in "Comment", with: "something"
@@ -105,7 +104,7 @@ RSpec.describe "Adjustment management", type: :system, js: true do
 
     it "should not display inactive storage locations in dropdown" do
       create(:storage_location, name: "Inactive R Us", discarded_at: Time.zone.now)
-      visit url_prefix + "/adjustments/new"
+      visit new_adjustment_path
       expect(page).to have_no_content "Inactive R Us"
     end
   end

--- a/spec/system/annual_reports_system_spec.rb
+++ b/spec/system/annual_reports_system_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe "Annual Reports", type: :system, js: true do
   let(:url_prefix) { "/#{@organization.short_name}" }
 
   context "while signed in as an organization admin" do
-    subject { url_prefix + "/reports/annual_reports" }
+    subject { reports_annual_reports_path }
     let!(:purchase) { create(:purchase, :with_items, item_quantity: 10, issued_at: 1.year.ago) }
 
     before do
       sign_in @organization_admin
-      visit subject.to_s
+      visit subject
     end
 
     it("exists") do
@@ -20,7 +20,7 @@ RSpec.describe "Annual Reports", type: :system, js: true do
     end
 
     it "has all the sub-reports we expect" do
-      visit subject.to_s
+      visit subject
       year = 1.year.ago.year
       click_on(year.to_s)
       expect(page).to have_content("Diaper Acquisition")

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Audit management", type: :system, js: true do
         visit subject
         click_link "New Audit"
         select storage_location.name, from: "Storage location"
+        find('select option[data-select2-id="3"]', wait: 10) # Prevents flakiness in line below (see #4248)
         select Item.last.name, from: "audit_line_items_attributes_0_item_id"
         fill_in "audit_line_items_attributes_0_quantity", with: quantity.to_s
 
@@ -88,6 +89,7 @@ RSpec.describe "Audit management", type: :system, js: true do
         visit subject
         click_link "New Audit"
         select storage_location.name, from: "Storage location"
+        find('select option[data-select2-id="3"]', wait: 10) # Prevents flakiness in line below (see #4248)
         select Item.last.name, from: "audit_line_items_attributes_0_item_id"
         fill_in "audit_line_items_attributes_0_quantity", with: quantity.to_s
 

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "Audit management", type: :system, js: true do
           expect(page).not_to have_content("Finalize Audit")
           visit edit_audit_path(id: audit.to_param)
           expect(page).not_to have_current_path(edit_audit_path(@organization.to_param, audit.to_param))
-          expect(page).to have_current_path(audits_path(@organization.to_param))
+          expect(page).to have_current_path(audits_path)
         end
 
         it "should not be able to delete the audit that is finalized" do

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe "Audit management", type: :system, js: true do
-  let!(:url_prefix) { "/#{@organization.to_param}" }
   let(:quantity) { 7 }
   let(:item) { create(:item) }
   let!(:storage_location) { create(:storage_location, :with_items, item: item, item_quantity: 10, organization: @organization) }
@@ -10,22 +9,22 @@ RSpec.describe "Audit management", type: :system, js: true do
     end
 
     it "should not be able to visit the audits #index page" do
-      visit url_prefix + "/audits"
+      visit audits_path
       expect(page).to have_content("Access Denied")
     end
 
     it "should not be able to visit the audits #new page" do
-      visit url_prefix + "/audits/new"
+      visit new_audit_path
       expect(page).to have_content("Access Denied")
     end
 
     it "should not be able to visit the audits #edit page" do
-      visit url_prefix + "/audits/1/edit"
+      visit edit_audit_path(1)
       expect(page).to have_content("Access Denied")
     end
 
     it "should not be able to visit the audits #show page" do
-      visit url_prefix + "/audits/1"
+      visit audit_path(1)
       expect(page).to have_content("Access Denied")
     end
   end
@@ -36,7 +35,7 @@ RSpec.describe "Audit management", type: :system, js: true do
     end
 
     context "when starting a new audit" do
-      subject { url_prefix + "/audits/new" }
+      subject { new_audit_path }
       let(:item) { Item.alphabetized.first }
 
       it "does not display quantities in line-item drop down selector" do
@@ -49,7 +48,7 @@ RSpec.describe "Audit management", type: :system, js: true do
     end
 
     context "when viewing the audits index" do
-      subject { url_prefix + "/audits" }
+      subject { audits_path }
 
       it "should be able to filter the #index by storage location" do
         storage_location2 = create(:storage_location, name: "there", organization: @organization)
@@ -106,7 +105,7 @@ RSpec.describe "Audit management", type: :system, js: true do
     end
 
     context "with an existing audit" do
-      subject { url_prefix + "/audits/" + audit.to_param }
+      subject { audit_path(id: audit.to_param) }
 
       let(:audit) { create(:audit, :with_items, storage_location: storage_location, item: item, item_quantity: quantity) }
 
@@ -135,7 +134,7 @@ RSpec.describe "Audit management", type: :system, js: true do
       end
 
       it "should be able to confirm the audit from the #edit page" do
-        visit url_prefix + "/audits/" + audit.to_param + "/edit"
+        visit edit_audit_path(id: audit.to_param)
         expect(page).to have_content("Confirm Audit")
         accept_confirm do
           click_button "Confirm Audit"
@@ -150,7 +149,7 @@ RSpec.describe "Audit management", type: :system, js: true do
     end
 
     context "with a confirmed audit" do
-      subject { url_prefix + "/audits/" + audit.to_param }
+      subject { audit_path(id: audit.to_param) }
       let(:audit) { create(:audit, :with_items, storage_location: storage_location, item: item, item_quantity: quantity, status: :confirmed) }
 
       it "should be able to edit the audit that is confirmed" do
@@ -208,7 +207,7 @@ RSpec.describe "Audit management", type: :system, js: true do
           expect(page).not_to have_content("Resume Audit")
           expect(page).not_to have_content("Delete Audit")
           expect(page).not_to have_content("Finalize Audit")
-          visit url_prefix + "/audits/" + audit.to_param + "/edit"
+          visit edit_audit_path(id: audit.to_param)
           expect(page).not_to have_current_path(edit_audit_path(@organization.to_param, audit.to_param))
           expect(page).to have_current_path(audits_path(@organization.to_param))
         end

--- a/spec/system/authorization_system_spec.rb
+++ b/spec/system/authorization_system_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe "Authorization", type: :system, js: true do
     sign_in(@user)
     visit dashboard_path(@user.organization)
 
-    expect(current_path).to eql "/#{@user.organization.short_name}/dashboard"
+    expect(current_path).to eql "/dashboard"
   end
 end

--- a/spec/system/authorization_system_spec.rb
+++ b/spec/system/authorization_system_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Authorization", type: :system, js: true do
 
   it "redirects to the organization dashboard when authorized" do
     sign_in(@user)
-    visit dashboard_path(@user.organization)
+    visit dashboard_path
 
     expect(current_path).to eql "/dashboard"
   end

--- a/spec/system/barcode_item_system_spec.rb
+++ b/spec/system/barcode_item_system_spec.rb
@@ -2,10 +2,9 @@ RSpec.describe "Barcode management", type: :system, js: true do
   before do
     sign_in(@user)
   end
-  let(:url_prefix) { "/#{@organization.to_param}" }
 
   context "While viewing the barcode items index page" do
-    subject { url_prefix + "/barcode_items" }
+    subject { barcode_items_path }
 
     before do
       Item.delete_all
@@ -72,7 +71,7 @@ RSpec.describe "Barcode management", type: :system, js: true do
     it "can have a user add a new barcode" do
       Item.delete_all
       item = create(:item, name: "1T Diapers")
-      visit url_prefix + "/barcode_items/new"
+      visit new_barcode_item_path
       select item.name, from: "Item"
       fill_in "Quantity", id: "barcode_item_quantity", with: barcode_traits[:quantity]
       fill_in "Barcode", id: "barcode_item_value", with: barcode_traits[:value]
@@ -88,7 +87,7 @@ RSpec.describe "Barcode management", type: :system, js: true do
     end
 
     context "when editing an existing barcode" do
-      subject { url_prefix + "/barcode_items/#{barcode.id}/edit" }
+      subject { edit_barcode_item_path(barcode.id) }
       let!(:barcode) { create(:barcode_item, organization_id: @organization.id) }
 
       it "saves the changes if they are valid" do
@@ -111,7 +110,7 @@ RSpec.describe "Barcode management", type: :system, js: true do
   end
 
   it "prevents a user from adding a new barcode with empty attributes" do
-    visit url_prefix + "/barcode_items/new"
+    visit new_barcode_item_path
     click_button "Save"
 
     expect(page.find(".alert")).to have_content "didn't work"

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -5,16 +5,15 @@ RSpec.describe "Dashboard", type: :system, js: true do
     before :each do
       @new_organization = create(:organization)
       @user = create(:user, organization: @new_organization)
-      @org_short_name = new_organization.short_name
     end
-    attr_reader :new_organization, :org_short_name, :user
+    attr_reader :new_organization, :user
 
     before do
       sign_in(user)
     end
 
     it "displays the getting started guide until the steps are completed" do
-      org_dashboard_page = OrganizationDashboardPage.new org_short_name: org_short_name
+      org_dashboard_page = OrganizationDashboardPage.new
       org_dashboard_page.visit
 
       # rubocop:disable Layout/ExtraSpacing
@@ -72,8 +71,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
     end
 
     let!(:storage_location) { create(:storage_location, :with_items, item_quantity: 1, organization: @organization) }
-    let(:org_short_name) { @organization.short_name }
-    let(:org_dashboard_page) { OrganizationDashboardPage.new org_short_name: org_short_name }
+    let(:org_dashboard_page) { OrganizationDashboardPage.new }
 
     describe "Signage" do
       it "shows their organization name unless they have a logo set" do

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -122,13 +122,11 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
     describe "Donations" do
       it "has a link to create a new donation" do
-        org_new_donation_page = OrganizationNewDonationPage.new org_short_name: org_short_name
-
         org_dashboard_page.visit
 
         expect { org_dashboard_page.create_new_donation }
           .to change { page.current_path }
-          .to org_new_donation_page.path
+          .to new_donation_path
       end
 
       # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter
@@ -240,13 +238,11 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
     describe "Purchases" do
       it "has a link to create a new purchase" do
-        org_new_purchase_page = OrganizationNewPurchasePage.new org_short_name: org_short_name
-
         org_dashboard_page.visit
 
         expect { org_dashboard_page.create_new_purchase }
           .to change { page.current_path }
-          .to org_new_purchase_page.path
+          .to new_purchase_path
       end
 
       # as of 28 Jan 2022, the "Recent Purchases" list shows up to this many items matching the date filter
@@ -694,13 +690,11 @@ RSpec.describe "Dashboard", type: :system, js: true do
       end
 
       it "has a link to create a new distribution" do
-        org_new_distribution_page = OrganizationNewDistributionPage.new org_short_name: org_short_name
-
         expect(org_dashboard_page.visit).to have_distributions_section
 
         expect { org_dashboard_page.create_new_distribution }
           .to change { page.current_path }
-          .to org_new_distribution_page.path
+          .to new_distribution_path
       end
 
       # as of 28 Jan 2022, the "Recent Donations" list shows up to this many items matching the date filter

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -1,7 +1,6 @@
 RSpec.feature "Distributions", type: :system do
   before do
     sign_in(@user)
-    @url_prefix = "/#{@organization.to_param}"
 
     @partner = create(:partner, organization: @organization)
 
@@ -17,7 +16,7 @@ RSpec.feature "Distributions", type: :system do
     end
 
     it "appears distribution in calendar with correct time & timezone" do
-      visit @url_prefix + "/distributions/schedule"
+      visit schedule_distributions_path
       expect(page.find(".fc-event-time")).to have_content "7p"
       expect(page.find(".fc-event-title")).to have_content @distribution.partner.name
     end
@@ -26,7 +25,7 @@ RSpec.feature "Distributions", type: :system do
   context "When creating a new distribution manually" do
     context "when the delivery_method is not shipped" do
       it "Allows a distribution to be created and shipping cost field not visible" do
-        visit @url_prefix + "/distributions/new"
+        visit new_distribution_path
 
         select @partner.name, from: "Partner"
         select @storage_location.name, from: "From storage location"
@@ -47,7 +46,7 @@ RSpec.feature "Distributions", type: :system do
     end
 
     it "Displays a complete form after validation errors" do
-      visit @url_prefix + "/distributions/new"
+      visit new_distribution_path
 
       # verify line items appear on initial load
       expect(page).to have_selector "#distribution_line_items"
@@ -64,7 +63,7 @@ RSpec.feature "Distributions", type: :system do
 
     context "when the delivery_method is shipped and shipping cost is none-negative" do
       it "Allows a distribution to be created" do
-        visit @url_prefix + "/distributions/new"
+        visit new_distribution_path
 
         select @partner.name, from: "Partner"
         select @storage_location.name, from: "From storage location"
@@ -93,7 +92,7 @@ RSpec.feature "Distributions", type: :system do
             @storage_location.id => { item.id => 20 }
           })
 
-        visit @url_prefix + "/distributions/new"
+        visit new_distribution_path
         select @partner.name, from: "Partner"
         select @storage_location.name, from: "From storage location"
         select2(page, 'distribution_line_items_item_id', item.name, position: 1)
@@ -116,7 +115,7 @@ RSpec.feature "Distributions", type: :system do
             @storage_location.id => { item.id => 20 }
           })
 
-        visit @url_prefix + "/distributions/new"
+        visit new_distribution_path
         select @partner.name, from: "Partner"
         select @storage_location.name, from: "From storage location"
         find('select option[data-select2-id="3"]', wait: 10)
@@ -131,7 +130,7 @@ RSpec.feature "Distributions", type: :system do
 
     context "when there is insufficient inventory to fulfill the Distribution" do
       it "gracefully handles the error" do
-        visit @url_prefix + "/distributions/new"
+        visit new_distribution_path
 
         select @partner.name, from: "Partner"
         select @storage_location.name, from: "From storage location"
@@ -157,20 +156,20 @@ RSpec.feature "Distributions", type: :system do
     context "when there is a default storage location" do
       it "automatically selects the default storage location" do
         @organization.default_storage_location = @storage_location.id
-        visit @url_prefix + "/distributions/new"
+        visit new_distribution_path
         expect(find("#distribution_storage_location_id").text).to eq(@storage_location.name)
       end
     end
     it "should not display inactive storage locations in dropdown" do
       inactive_location = create(:storage_location, name: "Inactive R Us", discarded_at: Time.zone.now)
       setup_storage_location(inactive_location)
-      visit @url_prefix + "/distributions/new"
+      visit new_distribution_path
       expect(page).to have_no_content "Inactive R Us"
     end
   end
 
   it "errors if user does not fill storage_location" do
-    visit @url_prefix + "/distributions/new"
+    visit new_distribution_path
 
     select @partner.name, from: "Partner"
     select "", from: "From storage location"
@@ -186,7 +185,7 @@ RSpec.feature "Distributions", type: :system do
 
     before do
       sign_in(@organization_admin)
-      visit @url_prefix + "/distributions"
+      visit distributions_path
     end
 
     it "the user can make changes" do
@@ -203,7 +202,7 @@ RSpec.feature "Distributions", type: :system do
       allow(DistributionMailer).to receive(:reminder_email).and_return(job)
       allow(job).to receive(:deliver_later)
 
-      visit @url_prefix + "/distributions"
+      visit distributions_path
       click_on "Edit", match: :first
       fill_in "Agency representative", with: "SOMETHING DIFFERENT"
       click_on "Save", match: :first
@@ -288,14 +287,14 @@ RSpec.feature "Distributions", type: :system do
       let!(:complete_distribution) { create(:distribution, :with_items, agency_rep: "A Person", organization: @user.organization, issued_at: Time.zone.today, state: :complete) }
 
       it "does not contain a Edit button" do
-        visit @url_prefix + "/distributions"
+        visit distributions_path
         expect(page).not_to have_button("Edit")
       end
 
       it "cannot be accessed directly" do
-        visit @url_prefix + "/distributions/#{past_distribution.id}/edit"
+        visit edit_distribution_path(past_distribution.id)
         expect(page.find(".alert-danger")).to have_content "you must be an organization admin"
-        visit @url_prefix + "/distributions/#{complete_distribution.id}/edit"
+        visit edit_distribution_path(complete_distribution.id)
         expect(page.find(".alert-danger")).to have_content "you must be an organization admin"
       end
     end
@@ -312,13 +311,13 @@ RSpec.feature "Distributions", type: :system do
       let!(:distribution) { create(:distribution, :with_items, agency_rep: "A Person", organization: @user.organization, issued_at: Time.zone.today.prev_day, state: :complete) }
 
       it "can click on Edit button and a warning appears " do
-        visit @url_prefix + "/distributions"
+        visit distributions_path
         click_on "Edit", match: :first
         expect(page.find(".alert-warning")).to have_content "The current date is past the date this distribution was scheduled for."
       end
 
       it "can be accessed directly" do
-        visit @url_prefix + "/distributions/#{distribution.id}/edit"
+        visit edit_distribution_path(distribution.id)
         expect(page).to have_no_css(".alert-danger")
         expect(page.find(".alert-warning")).to have_content "The current date is past the date this distribution was scheduled for."
       end
@@ -333,7 +332,7 @@ RSpec.feature "Distributions", type: :system do
       @distribution1 = create(:distribution, :with_items, item: item1, agency_rep: "A Person", organization: @user.organization)
       create(:distribution, :with_items, item: item2, agency_rep: "A Person", organization: @user.organization)
       @distribution3 = create(:distribution, :with_items, item: item3, agency_rep: "A Person", organization: @user.organization)
-      visit @url_prefix + "/distributions"
+      visit distributions_path
     end
 
     it 'the user sees value in row on index page' do
@@ -348,13 +347,13 @@ RSpec.feature "Distributions", type: :system do
 
     it 'the user sees value per item on show page' do
       # item value 10.50
-      visit @url_prefix + "/distributions/#{@distribution1.id}"
+      visit distribution_path(@distribution1.id)
       expect(page).to have_content "$10.50"
     end
 
     it 'the user sees total value on show page' do
       # 100 items * 10.5
-      visit @url_prefix + "/distributions/#{@distribution1.id}"
+      visit distribution_path(@distribution1.id)
       expect(page).to have_content "$1,050"
     end
   end
@@ -362,7 +361,7 @@ RSpec.feature "Distributions", type: :system do
   context "When showing a individual distribution" do
     let!(:distribution) { create(:distribution, :with_items, agency_rep: "A Person", organization: @user.organization, issued_at: Time.zone.today, state: :complete, delivery_method: "pick_up") }
 
-    before { visit @url_prefix + "/distributions/#{distribution.id}" }
+    before { visit distribution_path(distribution.id) }
 
     it "Show partner name in title" do
       expect(page).to have_content("Distribution from #{distribution.storage_location.name} to #{distribution.partner.name}")
@@ -372,7 +371,7 @@ RSpec.feature "Distributions", type: :system do
   context "When creating a distribution from a donation" do
     let(:donation) { create :donation, :with_items }
     before do
-      visit @url_prefix + "/donations/#{donation.id}"
+      visit donation_path(donation)
       sign_in(@organization_admin)
       click_on "Start a new Distribution"
       within "#new_distribution" do
@@ -454,7 +453,7 @@ RSpec.feature "Distributions", type: :system do
       request_items = [{ "item_id" => items[0], "quantity" => 10 }, { "item_id" => items[1], "quantity" => 10 }]
       @request = create :request, organization: @organization, request_items: request_items
 
-      visit @url_prefix + "/requests/#{@request.id}"
+      visit request_path(id: @request.id)
       click_on "Fulfill request"
       within "#new_distribution" do
         select @storage_location.name, from: "From storage location"
@@ -464,9 +463,10 @@ RSpec.feature "Distributions", type: :system do
 
       expect(page).to have_content("Distribution Complete")
 
+      @request = Request.last
       @distribution = Distribution.last
-      expect(@request.reload.distribution_id).to eq @distribution.id
-      expect(@request.reload).to be_status_fulfilled
+      expect(@request.distribution_id).to eq @distribution.id
+      expect(@request).to be_status_fulfilled
     end
 
     it "maintains the connection with the request even when there are initial errors" do
@@ -474,7 +474,7 @@ RSpec.feature "Distributions", type: :system do
       request_items = [{ "item_id" => items[0], "quantity" => 1000000 }, { "item_id" => items[1], "quantity" => 10 }]
       @request = create :request, organization: @organization, request_items: request_items
 
-      visit @url_prefix + "/requests/#{@request.id}"
+      visit request_path(id: @request.id)
       click_on "Fulfill request"
       within "#new_distribution" do
         select @storage_location.name, from: "From storage location"
@@ -489,16 +489,17 @@ RSpec.feature "Distributions", type: :system do
 
       expect(page).to have_content("Distribution Complete")
 
+      @request = Request.last
       @distribution = Distribution.last
-      expect(@request.reload.distribution_id).to eq @distribution.id
-      expect(@request.reload).to be_status_fulfilled
+      expect(@request.distribution_id).to eq @distribution.id
+      expect(@request).to be_status_fulfilled
     end
   end
 
   context "via barcode entry" do
     before(:each) do
       initialize_barcodes
-      visit @url_prefix + "/distributions/new"
+      visit new_distribution_path
     end
 
     it "allows users to add items via scanning them in by barcode", js: true do
@@ -519,7 +520,7 @@ RSpec.feature "Distributions", type: :system do
         click_on "Save"
       end
 
-      visit @url_prefix + "/distributions/new"
+      visit new_distribution_path
       Barcode.boop(barcode_value)
 
       expect(page).to have_text("Adult Briefs (Large/X-Large)")
@@ -528,7 +529,7 @@ RSpec.feature "Distributions", type: :system do
   end
 
   context "when filtering on the index page" do
-    subject { @url_prefix + "/distributions" }
+    subject { distributions_path }
     let(:item_category) { create(:item_category) }
     let(:item1) { create(:item, name: "Good item", item_category: item_category, organization: @organization) }
     let(:item2) { create(:item, name: "Crap item", organization: @organization) }
@@ -574,7 +575,7 @@ RSpec.feature "Distributions", type: :system do
         create(:distribution, :with_items, item: item1, organization: organization)
         create(:distribution, :with_items, item: item2, organization: organization)
 
-        visit "/#{organization.to_param}/distributions"
+        visit distributions_path
         # check for all distributions
         expect(page).to have_css("table tbody tr", count: 2)
         # filter
@@ -629,7 +630,7 @@ RSpec.feature "Distributions", type: :system do
   end
 
   it "allows completion of corrected distribution with depleted inventory item" do
-    visit @url_prefix + "/distributions/new"
+    visit new_distribution_path
     item = View::Inventory.new(@organization.id).items_for_location(@storage_location.id).first.db_item
     TestInventory.create_inventory(@organization,
       {

--- a/spec/system/distributions_by_county_system_spec.rb
+++ b/spec/system/distributions_by_county_system_spec.rb
@@ -1,8 +1,4 @@
 RSpec.feature "Distributions by County", type: :system do
-  let(:default_params) do
-    {organization_name: organization.to_param}
-  end
-
   include_examples "distribution_by_county"
 
   let(:year) { Time.current.year }
@@ -41,7 +37,7 @@ RSpec.feature "Distributions by County", type: :system do
   end
 
   def visit_distribution_by_county_with_specified_date_range(date_range_string)
-    visit dashboard_path(default_params)
+    visit dashboard_path
     find("#filters_date_range").click
 
     within ".container__predefined-ranges" do

--- a/spec/system/donation_site_system_spec.rb
+++ b/spec/system/donation_site_system_spec.rb
@@ -3,11 +3,10 @@ RSpec.describe "Donation Site", type: :system, js: true do
     sign_in(@user)
   end
 
-  let(:url_prefix) { "/#{@organization.to_param}" }
   let(:donation_site) { create(:donation_site) }
 
   context "When a user views the index page" do
-    subject { url_prefix + "/donation_sites" }
+    subject { donation_sites_path }
 
     it "should show donation sites in alphabetical order" do
       create(:donation_site, name: "Bcd")
@@ -54,7 +53,7 @@ RSpec.describe "Donation Site", type: :system, js: true do
   end
 
   context "When creating a new donation site" do
-    subject { url_prefix + "/donation_sites/new" }
+    subject { new_donation_site_path }
 
     it "creates a new donation site as a user only with the required fields" do
       visit subject
@@ -88,7 +87,7 @@ RSpec.describe "Donation Site", type: :system, js: true do
   end
 
   context "with an existing donation site" do
-    subject { url_prefix + "/donation_sites/#{donation_site.id}/edit" }
+    subject { edit_donation_site_path(donation_site.id) }
 
     it "updates an existing donation site's Name" do
       visit subject

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -1,15 +1,11 @@
 RSpec.describe "Donations", type: :system, js: true do
-  before do
-    @url_prefix = "/#{@organization.short_name}"
-  end
-
   context "When signed in as a normal user" do
     before do
       sign_in @user
     end
 
     context "When visiting the index page" do
-      subject { @url_prefix + "/donations" }
+      subject { donations_path }
 
       before do
         create(:donation)
@@ -33,7 +29,7 @@ RSpec.describe "Donations", type: :system, js: true do
         create(:donation, :with_items, item: item)
         item.update(active: false)
         item.reload
-        expect { visit(@url_prefix + "/donations") }.to_not raise_error
+        expect { visit(donations_path) }.to_not raise_error
       end
 
       it "should not display inactive storage locations in dropdown" do
@@ -44,7 +40,7 @@ RSpec.describe "Donations", type: :system, js: true do
     end
 
     context "When filtering on the index page" do
-      subject { @url_prefix + "/donations" }
+      subject { donations_path }
       let!(:item) { create(:item) }
 
       it "Filters by the source" do
@@ -161,7 +157,7 @@ RSpec.describe "Donations", type: :system, js: true do
 
       context "Via manual entry" do
         before do
-          visit @url_prefix + "/donations/new"
+          visit new_donation_path
         end
 
         # using this to also test user ID for events - it needs to be an actual controller action
@@ -436,7 +432,7 @@ RSpec.describe "Donations", type: :system, js: true do
       context "Via barcode entry" do
         before do
           initialize_barcodes
-          visit @url_prefix + "/donations/new"
+          visit new_donation_path
         end
 
         it "Allows User to add items by barcode", :js do
@@ -512,7 +508,7 @@ RSpec.describe "Donations", type: :system, js: true do
           end
 
           it "Adds the oldest item it can find for the global barcode" do
-            visit @url_prefix + "/donations/new"
+            visit new_donation_path
             within "#donation_line_items" do
               expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
               Barcode.boop(@global_barcode.value)
@@ -528,7 +524,7 @@ RSpec.describe "Donations", type: :system, js: true do
 
       it "should not display inactive storage locations in dropdown" do
         create(:storage_location, name: "Inactive R Us", discarded_at: Time.zone.now)
-        visit @url_prefix + "/donations/new"
+        visit new_donation_path
         expect(page).to have_no_content "Inactive R Us"
       end
     end
@@ -542,7 +538,7 @@ RSpec.describe "Donations", type: :system, js: true do
         create(:donation, :with_items, item: item2)
         create(:donation, :with_items, item: item3)
 
-        visit @url_prefix + "/donations"
+        visit donations_path
       end
 
       it 'Displays the individual value on the index page' do
@@ -554,7 +550,7 @@ RSpec.describe "Donations", type: :system, js: true do
       end
 
       it 'Displays the total value on the show page' do
-        visit @url_prefix + "/donations/#{@donation1.id}"
+        visit donation_path(@donation1.id)
         expect(page).to have_content "$125"
       end
     end
@@ -569,7 +565,7 @@ RSpec.describe "Donations", type: :system, js: true do
         create(:manufacturer, organization: @organization)
         create(:donation, :with_items, item: item, organization: @organization)
         @organization.reload
-        visit @url_prefix + "/donations/"
+        visit donations_path
       end
 
       it "Allows the user to edit a donation" do
@@ -633,7 +629,7 @@ RSpec.describe "Donations", type: :system, js: true do
       before do
         @donation = create(:donation, :with_items)
 
-        visit @url_prefix + "/donations/#{@donation.id}"
+        visit donation_path(@donation.id)
       end
 
       it "does not allow deletion of a donation" do
@@ -650,7 +646,7 @@ RSpec.describe "Donations", type: :system, js: true do
       context 'when there is no comment defined' do
         before do
           donation = create(:donation, :with_items, comment: nil)
-          visit @url_prefix + "/donations/#{donation.id}"
+          visit donation_path(donation.id)
         end
 
         it 'displays the None provided as the comment ' do
@@ -671,7 +667,7 @@ RSpec.describe "Donations", type: :system, js: true do
       before do
         @donation = create(:donation, :with_items, item_quantity: 1)
 
-        visit @url_prefix + "/donations/#{@donation.id}"
+        visit donation_path(@donation.id)
       end
 
       it "allows deletion of a donation" do

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Donations", type: :system, js: true do
       it "Allows User to click to the new donation form" do
         find(".fa-plus").click
 
-        expect(current_path).to eq(new_donation_path(@organization))
+        expect(current_path).to eq(new_donation_path)
         expect(page).to have_content "Start a new donation"
       end
 

--- a/spec/system/item_system_spec.rb
+++ b/spec/system/item_system_spec.rb
@@ -3,9 +3,8 @@ RSpec.describe "Item management", type: :system do
     sign_in(@user)
   end
 
-  let!(:url_prefix) { "/#{@organization.to_param}" }
   it "can create a new item as a user" do
-    visit url_prefix + "/items/new"
+    visit new_item_path
     item_traits = attributes_for(:item)
     fill_in "Name", with: item_traits[:name]
     select BaseItem.last.name, from: "Base Item"
@@ -15,14 +14,14 @@ RSpec.describe "Item management", type: :system do
   end
 
   it "can create a new item with empty attributes as a user" do
-    visit url_prefix + "/items/new"
+    visit new_item_path
     click_button "Save"
 
     expect(page.find(".alert")).to have_content "didn't work"
   end
 
   it "can create a new item with dollars decimal amount for value field" do
-    visit url_prefix + "/items/new"
+    visit new_item_path
     item_traits = attributes_for(:item)
     fill_in "Name", with: item_traits[:name]
     fill_in "item_value_in_dollars", with: '1,234.56'
@@ -36,7 +35,7 @@ RSpec.describe "Item management", type: :system do
 
   it "can update an existing item as a user" do
     item = create(:item)
-    visit url_prefix + "/items/#{item.id}/edit"
+    visit edit_item_path(item.id)
     click_button "Save"
 
     expect(page.find(".alert")).to have_content "updated"
@@ -44,7 +43,7 @@ RSpec.describe "Item management", type: :system do
 
   it "can update an existing item with empty attributes as a user" do
     item = create(:item)
-    visit url_prefix + "/items/#{item.id}/edit"
+    visit edit_item_path(item.id)
     fill_in "Name", with: ""
     click_button "Save"
 
@@ -53,10 +52,10 @@ RSpec.describe "Item management", type: :system do
 
   it "can make the item invisible to partners" do
     item = create(:item)
-    visit url_prefix + "/items/#{item.id}/edit"
+    visit edit_item_path(item.id)
     uncheck "visible_to_partners"
     click_button "Save"
-    visit url_prefix + "/items/#{item.id}/edit"
+    visit edit_item_path(item.id)
 
     # rubocop:disable Rails/DynamicFindBy
     expect(find_by_id("visible_to_partners").checked?).to be false
@@ -69,7 +68,7 @@ RSpec.describe "Item management", type: :system do
     Item.delete_all
     create(:item, base_item: BaseItem.first)
     create(:item, base_item: BaseItem.last)
-    visit url_prefix + "/items"
+    visit items_path
     select BaseItem.first.name, from: "filters[by_base_item]"
     click_button "Filter"
     within "#items-table" do
@@ -82,7 +81,7 @@ RSpec.describe "Item management", type: :system do
 
     it "allows a user to restore the item" do
       expect do
-        visit url_prefix + "/items"
+        visit items_path
         check "include_inactive_items"
         click_on "Filter"
         within "#items-table" do
@@ -114,7 +113,7 @@ RSpec.describe "Item management", type: :system do
     let!(:donation_tampons) { create(:donation, :with_items, storage_location: storage, item_quantity: num_tampons_in_donation, item: item_tampons) }
     let!(:donation_aux_tampons) { create(:donation, :with_items, storage_location: aux_storage, item_quantity: num_tampons_second_donation, item: item_tampons) }
     before do
-      visit url_prefix + "/items"
+      visit items_path
     end
 
     # Consolidated these into one to reduce the setup/teardown
@@ -161,7 +160,7 @@ RSpec.describe "Item management", type: :system do
 
   describe 'Item Category Management' do
     before do
-      visit url_prefix + "/items"
+      visit items_path
     end
 
     describe 'creating a new item category and associating to a new item' do

--- a/spec/system/kit_system_spec.rb
+++ b/spec/system/kit_system_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe "Kit management", type: :system do
     })
   end
 
-  let!(:url_prefix) { "/#{@organization.to_param}" }
-
   it "can create a new kit as a user with the proper quantity" do
-    visit url_prefix + "/kits/new"
+    visit new_kit_path
     kit_traits = attributes_for(:kit)
 
     fill_in "Name", with: kit_traits[:name]
@@ -50,7 +48,7 @@ RSpec.describe "Kit management", type: :system do
   end
 
   it 'can allocate and deallocate quantity per storage location from kit index' do
-    visit url_prefix + "/kits/"
+    visit kits_path
 
     click_on 'Modify Allocation'
 
@@ -115,7 +113,7 @@ RSpec.describe "Kit management", type: :system do
       name: "Fake Kit"
     }
     KitCreateService.new(organization_id: @organization.id, kit_params: kit_params).tap(&:call).kit
-    visit url_prefix + "/kits/"
+    visit kits_path
     expect(page).to have_no_text("Inactive R Us")
   end
 
@@ -126,7 +124,7 @@ RSpec.describe "Kit management", type: :system do
     end
 
     it 'will not change quantity amounts when allocating' do
-      visit url_prefix + "/kits/"
+      visit kits_path
 
       click_on 'Modify Allocation'
 
@@ -177,7 +175,7 @@ RSpec.describe "Kit management", type: :system do
     end
 
     it 'will not change quantity amounts when deallocating' do
-      visit url_prefix + "/kits/"
+      visit kits_path
 
       click_on 'Modify Allocation'
 

--- a/spec/system/layout_system_spec.rb
+++ b/spec/system/layout_system_spec.rb
@@ -1,14 +1,12 @@
 RSpec.describe "Layout", type: :system do
-  let!(:url_prefix) { "/#{@organization.to_param}" }
-
   describe "Body CSS Data" do
     it "sets the ID to the controller and the class to the action" do
       sign_in(@user)
-      visit url_prefix + "/donations/new"
+      visit new_donation_path
       expect(page).to have_css("body#donations.new")
 
       distribution = create(:distribution)
-      visit url_prefix + "/distributions/#{distribution.id}/edit"
+      visit edit_distribution_path(distribution.id)
       expect(page).to have_css("body#distributions.edit")
     end
   end

--- a/spec/system/manage_system_spec.rb
+++ b/spec/system/manage_system_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Organization Administration", type: :system, js: true do
-  subject { "/#{@organization.to_param}/organization" }
+  subject { organization_path }
 
   context "while signed in as a normal user" do
     before do

--- a/spec/system/manage_system_spec.rb
+++ b/spec/system/manage_system_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Organization Administration", type: :system, js: true do
     end
 
     it "can bail back to their own site as a user" do
-      expect(page).to have_xpath("//a[@href='#{dashboard_path(organization_name: @organization.to_param)}']")
+      expect(page).to have_xpath("//a[@href='#{dashboard_path}']")
     end
 
     it "can edit the properties for an organization as an admin" do

--- a/spec/system/manufacturer_system_spec.rb
+++ b/spec/system/manufacturer_system_spec.rb
@@ -2,15 +2,15 @@ RSpec.describe "Manufacturer", type: :system do
   before do
     sign_in(@user)
   end
-  let(:url_prefix) { "/#{@organization.to_param}" }
 
   context "When a user views the index page" do
     before(:each) do
       @second = create(:manufacturer, name: "Bcd")
       @first = create(:manufacturer, name: "Abc")
       @third = create(:manufacturer, name: "Cde")
-      visit url_prefix + "/manufacturers"
+      visit manufacturers_path
     end
+
     it "alphabetizes the manufacturer names" do
       expect(page).to have_xpath("//table//tr", count: 4)
       expect(page.find(:xpath, "//table/tbody/tr[1]/td[1]")).to have_content(@first.name)
@@ -19,7 +19,7 @@ RSpec.describe "Manufacturer", type: :system do
   end
 
   it "allows a user to create a new manufacturer instance" do
-    visit url_prefix + "/manufacturers/new"
+    visit new_manufacturer_path
     manufacturer_traits = attributes_for(:manufacturer)
     fill_in "Name", with: manufacturer_traits[:name]
 
@@ -31,7 +31,7 @@ RSpec.describe "Manufacturer", type: :system do
   end
 
   it "allows a user to add a new manufacturer instance with empty attributes" do
-    visit url_prefix + "/manufacturers/new"
+    visit new_manufacturer_path
     click_button "Save"
 
     expect(page.find(".alert")).to have_content "didn't work"
@@ -40,7 +40,7 @@ RSpec.describe "Manufacturer", type: :system do
   it "allows a user to update the contact info for a manufacturer" do
     manufacturer = create(:manufacturer)
     new_name = "New Manufacturer Name"
-    visit url_prefix + "/manufacturers/#{manufacturer.id}/edit"
+    visit edit_manufacturer_path(manufacturer.id)
     fill_in "Name", with: new_name
     click_button "Save"
 
@@ -50,7 +50,7 @@ RSpec.describe "Manufacturer", type: :system do
 
   it "allows a user to update a manufacturer with empty attributes" do
     manufacturer = create(:manufacturer)
-    visit url_prefix + "/manufacturers/#{manufacturer.id}/edit"
+    visit edit_manufacturer_path(manufacturer.id)
     fill_in "Name", with: ""
     click_button "Save"
 
@@ -66,13 +66,13 @@ RSpec.describe "Manufacturer", type: :system do
     end
 
     it "shows existing Manufacturers in the #index with some summary stats" do
-      visit url_prefix + "/manufacturers"
+      visit manufacturers_path
       expect(page).to have_xpath("//table/tbody/tr/td", text: @manufacturer.name)
       expect(page).to have_xpath("//table/tbody/tr/td", text: "105")
     end
 
     it "allows single Manufacturers to show semi-detailed stats about donations from that manufacturer" do
-      visit url_prefix + "/manufacturers/#{@manufacturer.to_param}"
+      visit manufacturer_path(@manufacturer)
       expect(page).to have_xpath("//tr", count: 4)
     end
   end

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe "Organization management", type: :system, js: true do
       it "can view organization details", :aggregate_failures do
         @organization.update!(one_step_partner_invite: true)
 
-        visit organization_path(@organization)
+        visit organization_path
 
         expect(page.find("h1")).to have_text(@organization.name)
-        expect(page).to have_link("Home", href: dashboard_path(@organization))
+        expect(page).to have_link("Home", href: dashboard_path)
 
         expect(page).to have_content("Organization Info")
         expect(page).to have_content("Contact Info")

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe "Organization management", type: :system, js: true do
   include ActionView::RecordIdentifier
-  let!(:url_prefix) { "/#{@organization.to_param}" }
 
   context "while signed in as a normal user" do
     before do
@@ -8,11 +7,11 @@ RSpec.describe "Organization management", type: :system, js: true do
     end
 
     it "can see summary details about the organization as a user" do
-      visit url_prefix + "/organization"
+      visit organization_path
     end
 
     it "cannot see 'Make user' button for admins" do
-      visit url_prefix + "/organization"
+      visit organization_path
       expect(page.find(".table.border")).to have_no_content "Make User"
     end
   end
@@ -52,7 +51,7 @@ RSpec.describe "Organization management", type: :system, js: true do
 
     describe "Editing the organization" do
       before do
-        visit url_prefix + "/manage/edit"
+        visit edit_organization_path
       end
 
       it "is prompted with placeholder text and a more helpful error message to ensure correct URL format as a user" do
@@ -137,7 +136,7 @@ RSpec.describe "Organization management", type: :system, js: true do
 
     it "can add a new user to an organization" do
       allow(User).to receive(:invite!).and_return(true)
-      visit url_prefix + "/organization"
+      visit organization_path
       click_on "Invite User to this Organization"
       within "#addUserModal" do
         fill_in "email", with: "some_new_user@website.com"
@@ -148,19 +147,19 @@ RSpec.describe "Organization management", type: :system, js: true do
 
     it "can re-invite a user to an organization after 7 days" do
       create(:user, name: "Ye Olde Invited User", invitation_sent_at: Time.current - 7.days)
-      visit url_prefix + "/organization"
+      visit organization_path
       expect(page).to have_xpath("//i[@alt='Re-send invitation']")
     end
 
     it "can see 'Make user' button for admins" do
       create(:organization_admin)
-      visit url_prefix + "/organization"
+      visit organization_path
       expect(page.find(".table.border")).to have_content "Make User"
     end
 
     it "can deactivate a user in the organization" do
       user = create(:user, name: "User to be deactivated")
-      visit url_prefix + "/organization"
+      visit organization_path
       accept_confirm do
         click_button dom_id(user, "dropdownMenu")
         click_link dom_id(user)
@@ -172,7 +171,7 @@ RSpec.describe "Organization management", type: :system, js: true do
 
     it "can re-activate a user in the organization" do
       user = create(:user, :deactivated)
-      visit url_prefix + "/organization"
+      visit organization_path
       accept_confirm do
         click_button dom_id(user, "dropdownMenu")
         click_link dom_id(user)

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -3,7 +3,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
     before do
       sign_in(@user)
     end
-    let!(:url_prefix) { "/#{@organization.to_param}" }
     let!(:page_content_wait) { 10 } # allow up to 10 seconds for content to load in the test
 
     describe 'approving a partner that is awaiting approval' do
@@ -15,7 +14,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
       context 'when the approval succeeds' do
         it 'should approve the partner' do
-          visit url_prefix + "/partners"
+          visit partners_path
 
           assert page.has_content? partner_awaiting_approval.name
           click_on 'Review Application'
@@ -37,7 +36,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         end
 
         it 'should show an error message and not approve the partner' do
-          visit url_prefix + "/partners"
+          visit partners_path
 
           assert page.has_content? partner_awaiting_approval.name
 
@@ -61,7 +60,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           }
         end
         before do
-          visit url_prefix + "/partners"
+          visit partners_path
           assert page.has_content? "Partner Agencies for #{@organization.name}"
 
           click_on 'New Partner Agency'
@@ -93,7 +92,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           }
         end
         before do
-          visit url_prefix + "/partners"
+          visit partners_path
           assert page.has_content? "Partner Agencies for #{@organization.name}"
           click_on 'New Partner Agency'
 
@@ -122,7 +121,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
       context "when partner is uninvited and one step partner invite setting is on" do
         it "shows Invite and Approve button and approves the partner when clicked" do
           @organization.update!(one_step_partner_invite: true)
-          visit url_prefix + "/partners"
+          visit partners_path
 
           assert page.has_content? "Invite and Approve"
           expect do
@@ -135,7 +134,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         it "does not show invite and approve button" do
           @organization.update!(one_step_partner_invite: false)
 
-          visit url_prefix + "/partners"
+          visit partners_path
 
           assert page.should have_no_content "Invite and Approve"
         end
@@ -148,7 +147,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
         before do
           sign_in(@user)
-          visit partners_path(@organization)
+          visit partners_path
         end
 
         it 'should notify the user that its been successful and change the partner status' do
@@ -168,7 +167,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         @invited = create(:partner, name: "Abc", status: :invited)
         @approved = create(:partner, :approved, name: "Cde", status: :approved)
         @deactivated = create(:partner, name: "Def", status: :deactivated)
-        visit url_prefix + "/partners"
+        visit partners_path
       end
 
       it "displays the partner agency names in alphabetical order" do
@@ -183,7 +182,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         partner = create(:partner, name: 'Charities')
         partner.primary_user.delete
 
-        visit url_prefix + "/partners"
+        visit partners_path
 
         accept_alert("Send an invitation to #{partner.name} to begin using the partner application?") do
           ele = find('tr', text: partner.name)
@@ -241,7 +240,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
     describe "#show" do
       context "when viewing an uninvited partner" do
         let(:uninvited) { create(:partner, name: "Uninvited Partner", status: :uninvited) }
-        subject { url_prefix + "/partners/#{uninvited.id}" }
+        subject { partner_path(uninvited.id) }
 
         it 'only has an edit option available' do
           visit subject
@@ -260,7 +259,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
           sign_in(partner.users.first)
         end
         it "redirects user to partners page root page (dashboard) with error message" do
-          visit url_prefix + "/partners/#{partner.id}"
+          visit partner_path(partner.id)
           expect(page).to have_content("Dashboard - #{partner.name}")
           expect(page.find(".alert-danger")).to have_content("You must be logged in as the essentials bank's organization administrator to approve partner applications.")
         end
@@ -268,7 +267,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
       context "when viewing a deactivated partner" do
         let(:deactivated) { create(:partner, name: "Deactivated Partner", status: :deactivated) }
-        subject { url_prefix + "/partners/#{deactivated.id}" }
+        subject { partner_path(deactivated.id) }
         it 'allows reactivation ' do
           visit subject
           expect(page).to have_selector(:link_or_button, 'Reactivate')
@@ -276,7 +275,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
       end
 
       context "when exporting as CSV" do
-        subject { url_prefix + "/partners/#{partner.id}" }
+        subject { partner_path(partner.id) }
 
         let(:partner) do
           partner = create(:partner, :approved)
@@ -316,7 +315,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
     end
 
     describe "#new" do
-      subject { url_prefix + "/partners/new" }
+      subject { new_partner_path }
 
       it "User can add a new partner" do
         visit subject
@@ -344,7 +343,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
     describe "#edit" do
       let!(:partner) { create(:partner, name: "Frank") }
-      subject { url_prefix + "/partners/#{partner.id}/edit" }
+      subject { edit_partner_path(partner.id) }
 
       it "User can update a partner" do
         visit subject
@@ -352,7 +351,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         fill_in "Name", with: name
         click_button "Update Partner"
 
-        expect(page).to have_current_path(url_prefix + "/partners/#{partner.id}")
+        expect(page).to have_current_path(partner_path(partner.id))
         partner.reload
         expect(partner.name).to eq(name)
       end
@@ -390,7 +389,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
       end
 
       context "when viewing a partner's users" do
-        subject { url_prefix + "/partners/#{partner.id}" }
+        subject { partner_path(partner.id) }
         let(:partner) { create(:partner, name: "Partner") }
         let(:partner_user) { partner.users.first }
         let(:invitation_sent_at) { partner_user.invitation_sent_at.to_formatted_s(:date_picker) }
@@ -419,7 +418,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
     describe 'changing partner group association' do
       before do
         sign_in(@user)
-        visit url_prefix + "/partners/#{@partner.id}"
+        visit partner_path(@partner.id)
       end
       let!(:existing_partner_group) { create(:partner_group) }
 
@@ -481,7 +480,6 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         sign_in(@user)
       end
 
-      let!(:url_prefix) { "/#{@organization.to_param}" }
       let!(:item_category_1) { create(:item_category, organization: @organization) }
       let!(:item_category_2) { create(:item_category, organization: @organization) }
       let!(:items_in_category_1) { create_list(:item, 3, item_category_id: item_category_1.id) }
@@ -489,7 +487,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 
       describe 'creating a new partner group' do
         it 'should allow creating a new partner group with item categories' do
-          visit url_prefix + "/partners"
+          visit partners_path
 
           click_on 'Groups'
           click_on 'New Partner Group'
@@ -513,7 +511,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
         end
 
         it 'should allow updating the partner name' do
-          visit url_prefix + "/partners"
+          visit partners_path
 
           click_on 'Groups'
           assert page.has_content? existing_partner_group.name, wait: page_content_wait
@@ -539,7 +537,7 @@ Capybara.using_wait_time 10 do # allow up to 10 seconds for content to load in t
 end
 
 def visit_approval_page(partner_name:)
-  visit url_prefix + "/partners"
+  visit partners_path
   ele = find('tr', text: partner_name)
   within(ele) { click_on "Review Application" }
 end

--- a/spec/system/product_drive_participant_system_spec.rb
+++ b/spec/system/product_drive_participant_system_spec.rb
@@ -3,12 +3,11 @@ RSpec.describe " Participant", type: :system, js: true do
     sign_in(@user)
   end
 
-  let(:url_prefix) { "/#{@organization.to_param}" }
   let(:product_drive) { create(:product_drive) }
   let(:product_drive_participant) { create(:product_drive_participant) }
 
   context "When a user views the index page" do
-    subject { url_prefix + "/product_drive_participants" }
+    subject { product_drive_participants_path }
 
     before(:each) do
       @second = create(:product_drive_participant, business_name: "Bcd")
@@ -36,14 +35,14 @@ RSpec.describe " Participant", type: :system, js: true do
       end
 
       it "allows single  Participants to show semi-detailed stats about donations from that product drive" do
-        visit url_prefix + "/product_drive_participants/#{product_drive_participant.to_param}"
+        visit product_drive_participant_path(product_drive_participant)
         expect(page).to have_xpath("//table/tbody/tr", count: 3)
       end
     end
   end
 
   context "when creating new product drive participants" do
-    subject { url_prefix + "/product_drive_participants/new" }
+    subject { new_product_drive_participant_path }
 
     it "allows a user to create a new product drive instance" do
       visit subject
@@ -68,7 +67,7 @@ RSpec.describe " Participant", type: :system, js: true do
   end
 
   context "when editing an existing product drive participant" do
-    subject { url_prefix + "/product_drive_participants/#{product_drive_participant.id}/edit" }
+    subject { edit_product_drive_participant_path(product_drive_participant.id) }
 
     it "allows a user to update the contact info for a product drive participant" do
       new_email = "foo@bar.com"

--- a/spec/system/product_drive_system_spec.rb
+++ b/spec/system/product_drive_system_spec.rb
@@ -3,11 +3,10 @@ RSpec.describe "Product Drives", type: :system, js: true do
 
   before do
     sign_in @user
-    @url_prefix = "/#{@organization.id}"
   end
 
   context "When visiting the index page without parameters" do
-    let(:subject) { @url_prefix + "/product_drives" }
+    let(:subject) { product_drives_path }
 
     around do |example|
       travel_to Time.zone.local(2019, 7, 1)
@@ -51,7 +50,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
   end
 
   context 'when creating a normal product drive' do
-    let(:subject) { @url_prefix + "/product_drives/new" }
+    let(:subject) { new_product_drive_path }
 
     before { visit subject }
 
@@ -84,7 +83,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
   end
 
   context 'when creating a Virtual Product Drive' do
-    let(:subject) { @url_prefix + "/product_drives/new" }
+    let(:subject) { new_product_drive_path }
 
     before { visit subject }
 
@@ -121,7 +120,7 @@ RSpec.describe "Product Drives", type: :system, js: true do
 
   context 'when showing a Product Drive with no end date' do
     let(:new_product_drive) { create(:product_drive, name: 'Endless drive', start_date: 3.weeks.ago, end_date: '') }
-    let(:subject) { @url_prefix + "/product_drives/#{new_product_drive.id}" }
+    let(:subject) { product_drive_path(new_product_drive.id) }
 
     it 'must be able to show the product drive' do
       visit subject

--- a/spec/system/profile_served_area_system_spec.rb
+++ b/spec/system/profile_served_area_system_spec.rb
@@ -7,13 +7,10 @@ RSpec.describe "Partners profile served area behaviour when accessed as bank", t
     partner1.profile.served_areas << create_list(:partners_served_area, 4,
       partner_profile: partner1.profile, client_share: 25)
   }
-  let!(:default_params) do
-    {organization_name: @organization.to_param, id: partner1.id, partner_id: partner1.id}
-  end
 
   context "changing the client share" do
     before do
-      visit edit_profile_path(default_params)
+      visit edit_profile_path(id: partner1.id, partner_id: partner1.id)
     end
 
     it "handles an invalid total client share properly" do

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -1,15 +1,13 @@
 RSpec.describe "Purchases", type: :system, js: true do
   include ItemsHelper
 
-  let(:url_prefix) { "/#{@organization.short_name}" }
-
   context "while signed in as a normal user" do
     before :each do
       sign_in @user
     end
 
     context "When visiting the index page" do
-      subject { url_prefix + "/purchases" }
+      subject { purchases_path }
 
       context "In the middle of the year" do
         before :each do
@@ -52,7 +50,7 @@ RSpec.describe "Purchases", type: :system, js: true do
       context "When filtering on the index page" do
         let!(:item) { create(:item, organization: @organization) }
         let(:storage) { create(:storage_location, organization: @organization) }
-        subject { url_prefix + "/purchases" }
+        subject { purchases_path }
 
         it "User can filter the #index by storage location" do
           storage1 = create(:storage_location, name: "storage1", organization: @organization)
@@ -74,7 +72,7 @@ RSpec.describe "Purchases", type: :system, js: true do
           create(:purchase, vendor: vendor2, organization: organization)
 
           sign_in create(:user, organization: organization)
-          visit "/#{organization.short_name}/purchases"
+          visit purchases_path
 
           expect(page).to have_css("table tbody tr", count: 2)
           select vendor1.business_name, from: "filters[from_vendor]"
@@ -93,7 +91,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         @vendor = create(:vendor, organization: @organization)
         @organization.reload
       end
-      subject { url_prefix + "/purchases/new" }
+      subject { new_purchase_path }
 
       context "via manual entry" do
         before(:each) do
@@ -141,7 +139,7 @@ RSpec.describe "Purchases", type: :system, js: true do
             click_button "Save"
           end.to change { Purchase.count }.by(1)
 
-          visit url_prefix + "/purchases/#{Purchase.last.id}"
+          visit purchase_path(Purchase.last)
 
           expected_date = "January 1 2001 (entered: #{Purchase.last.created_at.to_fs(:distribution_date)})"
           expected_breadcrumb_date = "#{@vendor.business_name} on January 1 2001"
@@ -152,7 +150,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         end
 
         it "Does not include inactive items in the line item fields" do
-          visit url_prefix + "/purchases/new"
+          visit new_purchase_path
 
           select @storage_location.name, from: "purchase_storage_location_id"
           expect(page).to have_content(@item.name)
@@ -224,7 +222,7 @@ RSpec.describe "Purchases", type: :system, js: true do
           @existing_barcode = create(:barcode_item, organization: @organization)
           @item_with_barcode = @existing_barcode.item
           @item_no_barcode = create(:item, organization: @organization)
-          visit url_prefix + "/purchases/new"
+          visit new_purchase_path
         end
 
         it "a user can add items via scanning them in by barcode" do
@@ -285,7 +283,7 @@ RSpec.describe "Purchases", type: :system, js: true do
     end
 
     context "When visiting an existing purchase" do
-      subject { url_prefix + "/purchases" }
+      subject { purchases_path }
 
       it "does not allow deletion of a purchase" do
         purchase = create(:purchase, organization: @organization)
@@ -297,7 +295,7 @@ RSpec.describe "Purchases", type: :system, js: true do
 
   context "while signed in as an @organization admin" do
     let!(:purchase) { create(:purchase, :with_items, item_quantity: 10, organization: @organization) }
-    subject { url_prefix + "/purchases" }
+    subject { purchases_path }
 
     before do
       sign_in @organization_admin

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         it "User can click to the new purchase form" do
           find(".fa-plus").click
 
-          expect(current_path).to eq(new_purchase_path(@organization))
+          expect(current_path).to eq(new_purchase_path)
           expect(page).to have_content "Start a new purchase"
         end
 
@@ -206,13 +206,13 @@ RSpec.describe "Purchases", type: :system, js: true do
       context "Editing purchase" do
         it "A user can see purchased_from value" do
           purchase = create(:purchase, purchased_from: "Old Vendor", organization: @organization)
-          visit edit_purchase_path(@organization.to_param, purchase)
+          visit edit_purchase_path(purchase)
           expect(page).to have_content("Vendor (Old Vendor)")
         end
 
         it "A user can view another organizations purchase" do
           purchase = create(:purchase, organization: create(:organization))
-          visit edit_purchase_path(@user.organization.short_name, purchase)
+          visit edit_purchase_path(purchase)
           expect(page).to have_content("Still haven't found what you're looking for")
         end
       end

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "Requests", type: :system, js: true do
-  let!(:url_prefix) { "/#{@organization.to_param}" }
-
   let(:item1) { create(:item, name: "Good item") }
   let(:item2) { create(:item, name: "Crap item") }
   let(:partner1) { create(:partner, name: "This Guy", email: "thisguy@example.com") }
@@ -21,7 +19,7 @@ RSpec.describe "Requests", type: :system, js: true do
   after { travel_back }
 
   context "#index" do
-    subject { url_prefix + "/requests" }
+    subject { requests_path }
 
     before do
       create(:request, :started, partner: partner1, request_items: [{ "item_id": item1.id, "quantity": '12' }])
@@ -119,7 +117,7 @@ RSpec.describe "Requests", type: :system, js: true do
   end
 
   context "#show" do
-    subject { url_prefix + "/requests/#{request.id}" }
+    subject { request_path(request.id) }
 
     let(:request_items) {
       [
@@ -179,7 +177,7 @@ RSpec.describe "Requests", type: :system, js: true do
       end
 
       it "should change to started" do
-        visit url_prefix + "/requests"
+        visit requests_path
         expect(page).to have_content "Started"
         expect(request.reload).to be_status_started
       end
@@ -208,7 +206,7 @@ RSpec.describe "Requests", type: :system, js: true do
     context 'when a bank user cancels a request' do
       let(:reason) { Faker::Lorem.sentence }
       before do
-        visit url_prefix + "/requests"
+        visit requests_path
       end
 
       it 'should set the request as canceled/discarded and contain the reason' do

--- a/spec/system/sign_in_system_spec.rb
+++ b/spec/system/sign_in_system_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe "User sign-in handling", type: :system, js: true do
       fill_in "Password", with: DEFAULT_USER_PASSWORD
       click_button "Log in"
 
-      expect(page).to have_current_path(
-        dashboard_path(organization_name: @user.organization)
-      )
+      expect(page).to have_current_path(dashboard_path)
     end
   end
 

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe "Storage Locations", type: :system, js: true do
   before do
     sign_in(@user)
   end
-  let!(:url_prefix) { "/#{@organization.to_param}" }
   let(:storage_location) { create(:storage_location) }
 
   context "when creating a new storage location" do
-    subject { url_prefix + "/storage_locations/new" }
+    subject { new_storage_location_path }
 
     it "User creates a new storage location" do
       visit subject
@@ -39,7 +38,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
   end
 
   context "when editing an existing storage location" do
-    subject { url_prefix + "/storage_locations/#{storage_location.id}/edit" }
+    subject { edit_storage_location_path(storage_location.id) }
 
     it "User updates an existing storage location" do
       visit subject
@@ -62,7 +61,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
   end
 
   context "when viewing the index" do
-    subject { url_prefix + "/storage_locations" }
+    subject { storage_locations_path }
 
     # BUG#1008
     it "shows totals that are the sum totals of all inputs" do
@@ -169,7 +168,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
     let(:item) { create(:item, name: "AAA Diapers") }
     let!(:storage_location) { create(:storage_location, :with_items, item: item, name: "here") }
     let!(:adjustment) { create(:adjustment, :with_items, storage_location: storage_location) }
-    subject { url_prefix + "/storage_locations/" + storage_location.id.to_s }
+    subject { storage_location_path(storage_location.id) }
 
     it "Items in (adjustments)" do
       visit subject

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -2,11 +2,10 @@ RSpec.describe "Transfer management", type: :system do
   before do
     sign_in(@user)
   end
-  let!(:url_prefix) { "/#{@organization.to_param}" }
   let(:item) { create(:item) }
 
   def create_transfer(amount, from_name, to_name)
-    visit url_prefix + "/transfers"
+    visit transfers_path
     click_link "New Transfer"
     within "form#new_transfer" do
       select from_name, from: "From storage location"
@@ -100,7 +99,7 @@ RSpec.describe "Transfer management", type: :system do
 
   it 'should not include inactive storage locations in dropdowns when creating a new transfer' do
     create(:storage_location, name: "Inactive R Us", discarded_at: Time.zone.now)
-    visit url_prefix + "/transfers/new"
+    visit new_transfer_path
     expect(page).to have_no_text 'Inactive R Us'
   end
 
@@ -115,7 +114,7 @@ RSpec.describe "Transfer management", type: :system do
   end
 
   context "when viewing the index page" do
-    subject { url_prefix + "/transfers" }
+    subject { transfers_path }
     it "can filter the #index by storage location both from and to as a user" do
       from_storage_location = create(:storage_location, name: "here", organization: @organization)
       to_storage_location = create(:storage_location, name: "there", organization: @organization)

--- a/spec/system/vendor_system_spec.rb
+++ b/spec/system/vendor_system_spec.rb
@@ -2,14 +2,13 @@ RSpec.describe "Vendor", type: :system, js: true do
   before do
     sign_in(@user)
   end
-  let(:url_prefix) { "/#{@organization.to_param}" }
 
   context "When a user views the index page" do
     before(:each) do
       @second = create(:vendor, business_name: "Bcd")
       @first = create(:vendor, business_name: "Abc")
       @third = create(:vendor, business_name: "Cde")
-      visit url_prefix + "/vendors"
+      visit vendors_path
     end
     it "should have the vendor names in alphabetical order" do
       expect(page).to have_xpath("//table//tr", count: 4)
@@ -19,7 +18,7 @@ RSpec.describe "Vendor", type: :system, js: true do
   end
 
   context "when creating a new vendor" do
-    subject { url_prefix + "/vendors/new" }
+    subject { new_vendor_path }
 
     it "can create a new vendor instance as a user" do
       visit subject
@@ -45,7 +44,7 @@ RSpec.describe "Vendor", type: :system, js: true do
 
   context "when editing an existing vendor" do
     let!(:vendor) { create(:vendor) }
-    subject { url_prefix + "/vendors/#{vendor.id}/edit" }
+    subject { edit_vendor_path(vendor.id) }
     it "can update the contact info for a vendor as a user" do
       new_email = "foo@bar.com"
       visit subject
@@ -76,13 +75,13 @@ RSpec.describe "Vendor", type: :system, js: true do
     end
 
     it "can have existing vendors show in the #index with some summary stats" do
-      visit url_prefix + "/vendors"
+      visit vendors_path
       expect(page).to have_xpath("//table/tbody/tr/td", text: @vendor.business_name)
       expect(page).to have_xpath("//table/tbody/tr/td", text: "25")
     end
 
     it "can have a single vendor show semi-detailed stats about purchases" do
-      visit url_prefix + "/vendors/#{@vendor.to_param}"
+      visit vendor_path(@vendor.to_param)
       expect(page).to have_xpath("//table/tbody/tr", count: 3)
       expect(page).to have_xpath("//table/tbody/tr/td", text: "10")
     end


### PR DESCRIPTION
Resolves #4240 

### Description

Refer to #4324 for original PR that is now split up into three parts.

Part 1 updates `routes.rb` to no longer use the `organization_name` scope. The controllers have also been updated to reflect this change

Part 2 contains changes to view files.

Part 3 contains changes to test files.

### Type of change

* New feature (non-breaking change which adds functionality) -> for users that are not super admins
* Breaking change (fix or feature that would cause existing functionality to not work as expected) -> super admins won’t be able to access routes outside of the `/admin` namespace (see Discussion section for #4324 )

### How Has This Been Tested?

Tests files have been updated under Part 3 (CI test suite will fail for Part 1 and Part 2).